### PR TITLE
🛡️ Sentinel: [HIGH] Fix Heap Buffer Overflow and Memory Safety in lacepr

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Use of uninitialized pointers in `access()` and failure to update caller's pointer after `realloc()` in `read_recal`.
 **Learning:** Command-line argument pointers in C were passed to `access()` without initialization or NULL checks, leading to crashes if arguments were missing. In `read_recal`, `realloc` was used on a pointer passed by value, meaning the caller still held the potentially freed original pointer.
 **Prevention:** Initialize all pointers to `NULL`, validate them before use, and pass pointers-to-pointers (e.g., `recal_t **data_ptr`) to functions that resize memory to ensure the caller's reference is updated.
+
+## 2025-05-17 - OOB Access in Cycle Indexing and Missing Memory Safety in lacepr
+**Vulnerability:** Heap buffer overflow when accessing `Cycle` and `cache` arrays with indices from `get_cycle_index`, plus multiple missing NULL checks for `malloc` and `samopen`.
+**Learning:** The `Cycle` array was sized to `MAX_CYCLE + 1`, but `get_cycle_index` could return values up to `2 * MAX_CYCLE`. This mismatch caused out-of-bounds writes. Also, `cache` was indexed by quality up to `MAX_Q` but only sized for `MAX_REASONABLE_Q`.
+**Prevention:** Ensure array dimensions fully cover the range of all potential index transformation functions. Implement defensive bounds checks at the point of access in high-frequency functions and strictly validate all memory allocations and library resource handles (like `HTSlib`'s `samopen`).

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -27,10 +27,14 @@ cache_t *cache;
 void init_cache (int n) {
   int i, j, k, l;
   cache = realloc(cache, n * sizeof(cache_t));
+  if (!cache && n > 0) {
+    fprintf(stderr, "Memory allocation failed for cache\n");
+    return;
+  }
   for (i=0; i < n; i++) {
-    for (j=0; j < MAX_REASONABLE_Q+1; j++) {
+    for (j=0; j < MAX_Q+1; j++) {
       for (k=0; k < MAX_CONTEXT+1; k++) {
-        for (l=0; l < MAX_CYCLE+1; l++) {
+        for (l=0; l < MAX_CYCLE_BINS; l++) {
           cache[i][j][k][l] = 0;
         }
       }
@@ -106,7 +110,7 @@ int delta (int origq, int obs, double err) {
   }
 }
 
-int newq (int8_t origq, int cycle, char preceding, char current, recal_t *recaldata, int recaldata_index) {
+int newq (uint8_t origq, int cycle, char preceding, char current, recal_t *recaldata, int recaldata_index) {
   int nq = 40;
   int running_q;
   int adjust_q = 0;
@@ -120,6 +124,14 @@ int newq (int8_t origq, int cycle, char preceding, char current, recal_t *recald
   context[2] = '\0';
   int con_i = get_context_index(context);
   int cyc_i = get_cycle_index(cycle);
+
+  if (origq > MAX_Q || recaldata_index < 0 || con_i < 0 || con_i > MAX_CONTEXT || cyc_i < 0 || cyc_i >= MAX_CYCLE_BINS) {
+    return origq;
+  }
+
+  if (cache == NULL) {
+    return origq;
+  }
 
   if (cache[recaldata_index][origq][con_i][cyc_i] > 0) {
     return cache[recaldata_index][origq][con_i][cyc_i];
@@ -233,9 +245,9 @@ int get_context_index (char *s) {
 // encode negatives as even numbers
 // 0 is bad data
 int get_cycle_index (int i) {
-  if (i > 0 && i < MAX_CYCLE) {
+  if (i > 0 && i <= MAX_CYCLE) {
     return (i*2-1);
-  } else if (i < 0 && -i < MAX_CYCLE) {
+  } else if (i < 0 && -i <= MAX_CYCLE) {
     return (-i*2);
   }
   return 0;	// bad data
@@ -245,6 +257,10 @@ int get_cycle_index (int i) {
 recal_t* init_recal (int num_rg) {
   int i, j, k;
   recal_t *data = malloc(sizeof(recal_t) * num_rg);
+  if (!data && num_rg > 0) {
+    fprintf(stderr, "Memory allocation failed for recal data\n");
+    return NULL;
+  }
   for (i=0; i < num_rg; i++) {
     data[i].Quality = 0;
     data[i].Observations = 0;
@@ -454,7 +470,10 @@ int read_group_check (samfile_t *fp, char** rglist, int num_rg, rg_item_t* rg_da
     j = 0;
     while (iter = sam_header2key_val(iter, "RG", "ID", KNOWN_RGFIELD[i], &key, &val)) {
       rg_data[i][j] = malloc(sizeof(rg_item_t));
-      if (!rg_data[i][j]) continue;
+      if (!rg_data[i][j]) {
+        fprintf(stderr, "Memory allocation failed for rg_data\n");
+        continue;
+      }
       strncpy(rg_data[i][j]->ID, key, MAX_FIELD - 1);
       rg_data[i][j]->ID[MAX_FIELD - 1] = '\0';
       strncpy(rg_data[i][j]->Value, val, MAX_FIELD - 1);
@@ -464,8 +483,10 @@ int read_group_check (samfile_t *fp, char** rglist, int num_rg, rg_item_t* rg_da
     }
     if (j < MAX_RG) {
       rg_data[i][j] = malloc(sizeof(rg_item_t));
-      rg_data[i][j]->ID[0] = '\0';
-      rg_data[i][j]->Value[0] = '\0';
+      if (rg_data[i][j]) {
+        rg_data[i][j]->ID[0] = '\0';
+        rg_data[i][j]->Value[0] = '\0';
+      }
     }
   }
   for(i = 0; i < 3; i++) {
@@ -601,10 +622,15 @@ int main (int argc, char *argv[])
   int good_rgfield_index;
 
   rg_item_t *rg_data[3][MAX_RG];
+  for(i=0; i<3; i++) {
+    for(j=0; j<MAX_RG; j++) {
+      rg_data[i][j] = NULL;
+    }
+  }
   char *forceable_rg;
   char *rgID;
   char *rg_search;
-  int rg_index;
+  int rg_index = -1;
   int force_rg_index = -1;
 
   sequence = 0;
@@ -613,8 +639,16 @@ int main (int argc, char *argv[])
 
   // read in the recal table
   rglist = malloc(MAX_RG * sizeof(char*));
+  if (!rglist) {
+    fprintf(stderr, "Memory allocation failed for rglist\n");
+    return 1;
+  }
   rglist[0] = NULL;
   recaldata = init_recal(1);
+  if (!recaldata) {
+    free(rglist);
+    return 1;
+  }
   num_rg = read_recal(recal_file, rglist, &recaldata);
   if (use_rg != NULL) {
     force_rg_index = get_rg_index(rglist, use_rg, false);
@@ -624,9 +658,18 @@ int main (int argc, char *argv[])
   }
   init_cache(num_rg);
 
-  if (access(inbam, F_OK) == 0) {	// we are processing a bam file
+  if (inbam && access(inbam, F_OK) == 0) {	// we are processing a bam file
     samfile_t *fp = samopen(inbam, "rb", 0);
+    if (!fp) {
+      fprintf(stderr, "Cannot open BAM file %s\n", inbam);
+      return 1;
+    }
     samfile_t *outfp = samopen(outfile, "wb", fp->header);
+    if (!outfp) {
+      fprintf(stderr, "Cannot open output BAM file %s\n", outfile);
+      samclose(fp);
+      return 1;
+    }
     bam_header_t *bh = fp->header;
     // set up rg_data so we can map from IDs back to read groups, which then
     // will get matched in rglist to choose the right recalibration data
@@ -726,7 +769,7 @@ int main (int argc, char *argv[])
     samclose(fp);
     return(0);
 
-  } else if (access(infastq, F_OK) == 0) {	// processing a fastq file
+  } else if (infastq && access(infastq, F_OK) == 0) {	// processing a fastq file
 
     gzFile fp;
     gzFile outp;

--- a/lacepr/lacepr.h
+++ b/lacepr/lacepr.h
@@ -1,4 +1,5 @@
 #define MAX_CYCLE 1024
+#define MAX_CYCLE_BINS (2 * MAX_CYCLE + 1)
 #define MAX_FIELD 256
 #define MAX_RG 256
 #define MIN_Q 2
@@ -84,11 +85,11 @@ typedef struct {
   int Observations;
   double Errors;
   point_recal_t OrigQual[MAX_Q + 1];
-  recal_set_t Cycle[MAX_CYCLE + 1];
+  recal_set_t Cycle[MAX_CYCLE_BINS];
   recal_set_t Context[MAX_CONTEXT + 1];
 } recal_t;
 
-typedef int cache_t[MAX_REASONABLE_Q + 1][MAX_CONTEXT + 1][MAX_CYCLE + 1];
+typedef int cache_t[MAX_Q + 1][MAX_CONTEXT + 1][MAX_CYCLE_BINS];
 
 // http://stackoverflow.com/questions/3981510/getline-check-if-line-is-whitespace
 int whitespaceline (const char *s) {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Multiple heap buffer overflows due to incorrect array dimensions for cycle and quality indexing, plus several potential NULL pointer dereferences in resource allocation.
🎯 Impact: Exploitation could lead to arbitrary code execution, sensitive data corruption, or denial-of-service (crashes).
🔧 Fix:
- Expanded `Cycle` and `cache` array dimensions to correctly accommodate indices.
- Implemented robust bounds checks in `newq` before array access.
- Added NULL pointer checks for all `malloc`, `realloc`, and `samopen` calls.
- Initialized critical pointers and variables in `main` to prevent garbage dereferences.
✅ Verification: Code review performed and marked as correct. Build verified for syntax (within environment constraints).

---
*PR created automatically by Jules for task [3757634191443291887](https://jules.google.com/task/3757634191443291887) started by @swainechen*