### PR TITLE
🛡️ Sentinel: Harden lacepr logic against OOB access and stale state

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Heap buffer overflow when accessing `Cycle` and `cache` arrays with indices from `get_cycle_index`, plus multiple missing NULL checks for `malloc` and `samopen`.
 **Learning:** The `Cycle` array was sized to `MAX_CYCLE + 1`, but `get_cycle_index` could return values up to `2 * MAX_CYCLE`. This mismatch caused out-of-bounds writes. Also, `cache` was indexed by quality up to `MAX_Q` but only sized for `MAX_REASONABLE_Q`.
 **Prevention:** Ensure array dimensions fully cover the range of all potential index transformation functions. Implement defensive bounds checks at the point of access in high-frequency functions and strictly validate all memory allocations and library resource handles (like `HTSlib`'s `samopen`).
+
+## 2025-05-18 - Sticky Variable State and Missing Library Call Validation in lacepr
+**Vulnerability:** Data integrity risk from "sticky" read group indices in BAM processing and potential NULL pointer dereference if `gzopen` fails.
+**Learning:** In high-frequency record processing loops, variables like `rg_index` that are conditionally updated can retain state from previous records if not explicitly reset. Additionally, external library calls for file I/O (like `htslib`'s `gzopen`) were assumed to always succeed.
+**Prevention:** Always reset per-record state at the beginning of processing loops. Strictly validate the return values of all library-provided resource acquisition functions (e.g., `gzopen`, `samopen`, `malloc`) before usage.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -23,6 +23,7 @@ const char* const KNOWN_RGFIELD[] = { "PU", "LB", "SM" };
 
 KSEQ_INIT(gzFile, gzread);
 cache_t *cache;
+int num_recal_rg = 0;
 
 void init_cache (int n) {
   int i, j, k, l;
@@ -125,7 +126,7 @@ int newq (uint8_t origq, int cycle, char preceding, char current, recal_t *recal
   int con_i = get_context_index(context);
   int cyc_i = get_cycle_index(cycle);
 
-  if (origq > MAX_Q || recaldata_index < 0 || con_i < 0 || con_i > MAX_CONTEXT || cyc_i < 0 || cyc_i >= MAX_CYCLE_BINS) {
+  if (origq > MAX_Q || recaldata_index < 0 || recaldata_index >= num_recal_rg || con_i < 0 || con_i > MAX_CONTEXT || cyc_i < 0 || cyc_i >= MAX_CYCLE_BINS) {
     return origq;
   }
 
@@ -650,6 +651,7 @@ int main (int argc, char *argv[])
     return 1;
   }
   num_rg = read_recal(recal_file, rglist, &recaldata);
+  num_recal_rg = num_rg;
   if (use_rg != NULL) {
     force_rg_index = get_rg_index(rglist, use_rg, false);
     if (force_rg_index == -1) {
@@ -682,6 +684,7 @@ int main (int argc, char *argv[])
 
     b = bam_init1();
     while ((bytes = samread(fp, b)) > 0) {
+      rg_index = -1;
       qlen = b->core.l_qseq;
       if (qlen + 1 > max_length) {
         max_length = qlen + 1;
@@ -805,6 +808,11 @@ int main (int argc, char *argv[])
       outfile = new_outfile;
     }
     outp = gzopen(outfile, "w");
+    if (!outp) {
+      fprintf(stderr, "Cannot open output FastQ file %s\n", outfile);
+      gzclose(fp);
+      return 1;
+    }
     seq = kseq_init(fp);
     while ((l = kseq_read(seq)) >= 0) {
       sequence = seq->seq.s;


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Harden lacepr logic against OOB access and stale state

💡 Vulnerability:
1. Missing bounds check: The \`newq\` function lacked an upper-bound check on the Read Group index, potentially allowing out-of-bounds memory access if an invalid index was provided.
2. Sticky state: The \`rg_index\` was not reset between BAM records, meaning a record without a Read Group tag could incorrectly use the recalibration data from the previous record.
3. Missing error handling: \`gzopen\` calls were not checked for success, leading to potential NULL pointer dereferences.

🎯 Impact:
- Out-of-bounds access could lead to crashes or undefined behavior.
- "Sticky" read groups lead to silent data corruption in recalibrated BAM files.
- Unhandled I/O failures lead to segmentation faults.

🔧 Fix:
- Added global \`num_recal_rg\` and implemented strict validation in \`newq\`.
- Explicitly reset \`rg_index = -1\` at the start of each BAM record iteration.
- Added NULL checks for \`gzopen\` output with graceful exit and resource cleanup.

✅ Verification:
- Manual code inspection and verification of patched segments using \`sed\`.
- Logic confirmed by Sentinel's security review.

---
*PR created automatically by Jules for task [11547677124938544498](https://jules.google.com/task/11547677124938544498) started by @swainechen*