### PR TITLE
🛡️ Sentinel: Fix OOB access in recalibration file parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** Data integrity risk from "sticky" read group indices in BAM processing and potential NULL pointer dereference if `gzopen` fails.
 **Learning:** In high-frequency record processing loops, variables like `rg_index` that are conditionally updated can retain state from previous records if not explicitly reset. Additionally, external library calls for file I/O (like `htslib`'s `gzopen`) were assumed to always succeed.
 **Prevention:** Always reset per-record state at the beginning of processing loops. Strictly validate the return values of all library-provided resource acquisition functions (e.g., `gzopen`, `samopen`, `malloc`) before usage.
+
+## 2025-05-19 - OOB Array Access via Malformed Recalibration Files in lacepr
+**Vulnerability:** Out-of-bounds (OOB) memory access when parsing GATK-style recalibration tables in `read_recal`, where `rgindex`, `qual`, and `covindex` were used as array indices without bounds checking.
+**Learning:** External data from files (even those typically produced by trusted tools like `lacer.pl`) must be treated as untrusted. Indices derived from `sscanf` can exceed array dimensions, leading to heap/stack corruption.
+**Prevention:** Always implement explicit bounds checks (e.g., `if (index >= 0 && index < MAX_SIZE)`) immediately after parsing and before using the index to access any array or allocated memory.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -149,7 +149,7 @@ int newq (uint8_t origq, int cycle, char preceding, char current, recal_t *recal
     adjust_con = delta(running_q, recaldata[recaldata_index].Context[con_i].OrigQual[origq].Observations, recaldata[recaldata_index].Context[con_i].OrigQual[origq].Errors);
 //printf("base %d, context %s, index %d, obs %d, err %f, adjust_q %d\n", running_q, context, con_i, recaldata[recaldata_index].Context[con_i].OrigQual[origq].Observations, recaldata[recaldata_index].Context[con_i].OrigQual[origq].Errors, adjust_con);
   }
-  if (recaldata[recaldata_index].Cycle[get_cycle_index(cycle)].OrigQual[origq].Observations > 0) {
+  if (recaldata[recaldata_index].Cycle[cyc_i].OrigQual[origq].Observations > 0) {
     adjust_cyc = delta(running_q, recaldata[recaldata_index].Cycle[cyc_i].OrigQual[origq].Observations, recaldata[recaldata_index].Cycle[cyc_i].OrigQual[origq].Errors);
 //printf("base %d, cycle %d, index %d, obs %d, err %f, adjust_q %d\n", running_q, cycle, cyc_i, recaldata[recaldata_index].Cycle[cyc_i].OrigQual[origq].Observations, recaldata[recaldata_index].Cycle[cyc_i].OrigQual[origq].Errors, adjust_cyc);
   }
@@ -344,6 +344,10 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
                 parsed = sscanf(in, "%255s %3s %lf %lf %d %lf", rg, eventtype, &empqual, &estqual, &obs, &err);
                 if (parsed == 6) {
                   rgindex = get_rg_index(rglist, rg, true);
+                  if (rgindex < 0 || rgindex >= MAX_RG) {
+                    fprintf(stderr, "Invalid read group index %d\n", rgindex);
+                    continue;
+                  }
                   temp_table0[rgindex].Quality = lround(empqual);
                   temp_table0[rgindex].Observations = obs;
                   temp_table0[rgindex].Errors = err;
@@ -396,6 +400,10 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
                 parsed = sscanf(in, "%255s %d %3s %lf %d %lf", rg, &qual, eventtype, &empqual, &obs, &err);
                 if (parsed == 6 && strcmp(eventtype,"M") == 0) {
                   rgindex = get_rg_index(rglist, rg, false);
+                  if (rgindex < 0 || rgindex >= num_rg || qual < 0 || qual > MAX_Q) {
+                    fprintf(stderr, "Invalid RG index %d or Quality %d\n", rgindex, qual);
+                    continue;
+                  }
                   data[rgindex].OrigQual[qual].Quality = lround(empqual);
                   data[rgindex].OrigQual[qual].Observations = obs;
                   data[rgindex].OrigQual[qual].Errors = err;
@@ -420,16 +428,20 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
                 parsed = sscanf(in, "%255s %d %255s %255s %3s %lf %d %lf", rg, &qual, covariate, covname, eventtype, &empqual, &obs, &err);
                 if (parsed == 8 && strcmp(eventtype,"M") == 0) {
                   rgindex = get_rg_index(rglist, rg, false);
+                  if (rgindex < 0 || rgindex >= num_rg || qual < 0 || qual > MAX_Q) {
+                    fprintf(stderr, "Invalid RG index %d or Quality %d\n", rgindex, qual);
+                    continue;
+                  }
                   if (strcmp(covname, "Cycle") == 0) {
                     // covariate is a string but if it's cycle it's a number
-                    if ((covindex = get_cycle_index(atoi(covariate))) != -1) {
+                    if ((covindex = get_cycle_index(atoi(covariate))) != -1 && covindex < MAX_CYCLE_BINS) {
                       data[rgindex].Cycle[covindex].OrigQual[qual].Quality = lround(empqual);
                       data[rgindex].Cycle[covindex].OrigQual[qual].Observations = obs;
                       data[rgindex].Cycle[covindex].OrigQual[qual].Errors = err;
 //                  printf("Table 2: %d, %s, %d, %s, %s, %s, %f, %d, %f\n", parsed, rg, qual, covariate, covname, eventtype, empqual, data[rgindex].Cycle[covindex].OrigQual[qual].Observations, data[rgindex].Cycle[covindex].OrigQual[qual].Errors);
                     }
                   } else if (strcmp(covname, "Context") == 0) {
-                    if ((covindex = get_context_index(covariate)) != -1) {
+                    if ((covindex = get_context_index(covariate)) != -1 && covindex <= MAX_CONTEXT) {
                       data[rgindex].Context[covindex].OrigQual[qual].Quality = lround(empqual);
                       data[rgindex].Context[covindex].OrigQual[qual].Observations = obs;
                       data[rgindex].Context[covindex].OrigQual[qual].Errors = err;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Out-of-bounds (OOB) memory access in `read_recal` and potential inconsistency in `newq`.
🎯 Impact: Malformed recalibration files could cause a crash (DoS) or potentially be exploited for arbitrary code execution due to OOB writes to the heap.
🔧 Fix: Implemented explicit bounds checking for all indices derived from file input before they are used to index into arrays.
✅ Verification: Manually verified the presence of checks via `grep` and reviewed logic against defined constants (`MAX_RG`, `MAX_Q`, `MAX_CYCLE_BINS`, `MAX_CONTEXT`).

---
*PR created automatically by Jules for task [3149799748852299448](https://jules.google.com/task/3149799748852299448) started by @swainechen*