### PR TITLE
🛡️ Sentinel: Fix double-free and buffer overflow in FASTQ processing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** Potential stack overflow via VLA, NULL pointer dereference in library calls, and unsafe realloc usage.
 **Learning:** `lacepr.c` used a variable-length array (VLA) on the stack for BAM record backups, which poses a DoS risk for large records. It also failed to validate `gzopen` handles and used an unsafe `realloc` pattern that could leak memory on failure.
 **Prevention:** Avoid VLAs for variable data on the stack; use direct pointer offsets or heap allocation. Always use a temporary pointer with `realloc` and validate all external resource handles (like `gzFile`) immediately after acquisition.
+
+## 2025-05-21 - Double-Free and Length Mismatch Vulnerabilities in FASTQ Processing
+**Vulnerability:** Double-free of internal `kseq` buffers and potential heap buffer overflow due to missing length validation between sequence and quality strings in FASTQ records.
+**Learning:** Assigning global pointers to internal library buffers (like `kseq`'s `seq.s`) that are managed by the library (e.g., freed via `kseq_destroy`) can lead to double-free vulnerabilities if the global pointer is also explicitly freed. Furthermore, assuming that sequence and quality strings in a FASTQ file are always the same length and null-terminated can lead to out-of-bounds access if only `strlen` is used.
+**Prevention:** Use local pointers for temporary library-managed buffers to avoid accidental double-frees. Always validate that related data fields (like sequence and quality in FASTQ) have matching lengths using the library's provided length fields before processing, and use length-limited copy functions like `memcpy` with manual null-termination.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -843,9 +843,13 @@ int main (int argc, char *argv[])
     }
     seq = kseq_init(fp);
     while ((l = kseq_read(seq)) >= 0) {
-      sequence = seq->seq.s;
-      qlen = strlen(sequence);
-      quality = seq->qual.s;
+      char *seq_ptr = seq->seq.s;
+      char *qual_ptr = seq->qual.s;
+      if (seq->seq.l != seq->qual.l) {
+        fprintf(stderr, "Sequence and quality lengths differ for %s; skipping\n", seq->name.s);
+        continue;
+      }
+      qlen = (int)seq->seq.l;
       if (qlen + 1 > newquality_size) {
         newquality_size = qlen + 1;
         char *tmp_q = realloc(newquality, newquality_size);
@@ -860,24 +864,25 @@ int main (int argc, char *argv[])
         newquality = tmp_q;
       }
       if (newquality) {
-        strcpy(newquality, quality);
+        memcpy(newquality, qual_ptr, qlen);
+        newquality[qlen] = '\0';
       }
       for (i = 0; i < qlen; i++) {
-        current = sequence[i];
+        current = seq_ptr[i];
         cycle = i+1;
         if (read_pairnum == 2) { cycle = -cycle; }
         if (i > 0) {
-          preceding = sequence[i-1];
+          preceding = seq_ptr[i-1];
         } else {
           preceding = '.';
         }
-        debug && fprintf(stderr, "cycle %d, sequence %d, pre %c, cur %c, orig %d, new %d\n", cycle, sequence[i], preceding, current, quality[i] - 33, newq(quality[i] - 33, cycle, preceding, current, recaldata, rg_index));
-        newquality[i] = newq(quality[i] - 33, cycle, preceding, current, recaldata, rg_index) + 33;
+        debug && fprintf(stderr, "cycle %d, sequence %d, pre %c, cur %c, orig %d, new %d\n", cycle, seq_ptr[i], preceding, current, qual_ptr[i] - 33, newq(qual_ptr[i] - 33, cycle, preceding, current, recaldata, rg_index));
+        newquality[i] = newq(qual_ptr[i] - 33, cycle, preceding, current, recaldata, rg_index) + 33;
       }
-      if (seq->comment.s == NULL || strlen(seq->comment.s) < 1) {
-        gzprintf(outp, "@%s\n%s\n+\n%s\n", seq->name.s, sequence, newquality);
+      if (seq->comment.s == NULL || seq->comment.l < 1) {
+        gzprintf(outp, "@%s\n%s\n+\n%s\n", seq->name.s, seq_ptr, newquality);
       } else {
-        gzprintf(outp, "@%s %s\n%s\n+\n%s\n", seq->name.s, seq->comment.s, sequence, newquality);
+        gzprintf(outp, "@%s %s\n%s\n+\n%s\n", seq->name.s, seq->comment.s, seq_ptr, newquality);
       }
     }
     kseq_destroy(seq);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Double-free of library-managed buffers and Heap Buffer Overflow.
🎯 Impact: Denial of Service (DoS) due to crashes or potential arbitrary code execution on malformed FASTQ files.
🔧 Fix: Refactored the FASTQ processing loop in `lacepr/lacepr.c` to use local pointers instead of reassigning the global `sequence` pointer. Added explicit length validation checks using `kseq`'s internal length fields and replaced `strcpy` with `memcpy` for safe buffer management.
✅ Verification: Performed manual code review and verified the changes by reading the modified source code. Verified that no syntax errors were introduced. Compilation was attempted but dependencies were unavailable in the sandbox.

---
*PR created automatically by Jules for task [4999111602316897626](https://jules.google.com/task/4999111602316897626) started by @swainechen*