### PR TITLE
🛡️ Sentinel: Improve memory safety and initialization in lacepr.c

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -37,3 +37,8 @@
 **Vulnerability:** Double-free of internal `kseq` buffers and potential heap buffer overflow due to missing length validation between sequence and quality strings in FASTQ records.
 **Learning:** Assigning global pointers to internal library buffers (like `kseq`'s `seq.s`) that are managed by the library (e.g., freed via `kseq_destroy`) can lead to double-free vulnerabilities if the global pointer is also explicitly freed. Furthermore, assuming that sequence and quality strings in a FASTQ file are always the same length and null-terminated can lead to out-of-bounds access if only `strlen` is used.
 **Prevention:** Use local pointers for temporary library-managed buffers to avoid accidental double-frees. Always validate that related data fields (like sequence and quality in FASTQ) have matching lengths using the library's provided length fields before processing, and use length-limited copy functions like `memcpy` with manual null-termination.
+
+## 2025-05-22 - Partial Initialization and Unsafe realloc in lacepr.c
+**Vulnerability:** Uninitialized memory usage due to incorrect loop boundaries in `init_recal` and potential memory leaks/crashes from unsafe `realloc` usage.
+**Learning:** Arrays sized by constants like `MAX_CONTEXT + 1` or `MAX_CYCLE_BINS` must be fully initialized using the same constants as loop boundaries. Additionally, assigning `realloc` results directly to the original pointer leads to memory leaks if allocation fails, as the handle to the original block is lost.
+**Prevention:** Always use the exact array size constant (or size-calculating expression) for loop boundaries during initialization. In C, always use a temporary pointer for `realloc` and only update the original pointer after verifying success.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -27,11 +27,12 @@ int num_recal_rg = 0;
 
 void init_cache (int n) {
   int i, j, k, l;
-  cache = realloc(cache, n * sizeof(cache_t));
-  if (!cache && n > 0) {
+  cache_t *tmp_cache = realloc(cache, n * sizeof(cache_t));
+  if (!tmp_cache && n > 0) {
     fprintf(stderr, "Memory allocation failed for cache\n");
     return;
   }
+  cache = tmp_cache;
   for (i=0; i < n; i++) {
     for (j=0; j < MAX_Q+1; j++) {
       for (k=0; k < MAX_CONTEXT+1; k++) {
@@ -271,14 +272,14 @@ recal_t* init_recal (int num_rg) {
       data[i].OrigQual[j].Observations = 0;
       data[i].OrigQual[j].Errors = 0;
     }
-    for (j=0; j < MAX_CONTEXT; j++) {
+    for (j=0; j < MAX_CONTEXT+1; j++) {
       for (k=0; k < MAX_Q+1; k++) {
         data[i].Context[j].OrigQual[k].Quality = 0;
         data[i].Context[j].OrigQual[k].Observations = 0;
         data[i].Context[j].OrigQual[k].Errors = 0;
       }
     }
-    for (j=0; j < MAX_CYCLE; j++) {
+    for (j=0; j < MAX_CYCLE_BINS; j++) {
       for (k=0; k < MAX_Q+1; k++) {
         data[i].Cycle[j].OrigQual[k].Quality = 0;
         data[i].Cycle[j].OrigQual[k].Observations = 0;
@@ -534,7 +535,7 @@ int read_group_check (samfile_t *fp, char** rglist, int num_rg, rg_item_t* rg_da
       for(i = 0; i < 3; i++) {
         fprintf(stderr, "- RG Field %s\n", KNOWN_RGFIELD[i]);
         for(j = 0; j < MAX_RG; j++) {
-          if (rg_data[i][j]->Value[0] == '\0') { break; }
+          if (rg_data[i][j] == NULL || rg_data[i][j]->Value[0] == '\0') { break; }
           fprintf(stderr, "  %s\n", rg_data[i][j]->Value);
         }
       }
@@ -663,6 +664,15 @@ int main (int argc, char *argv[])
     return 1;
   }
   num_rg = read_recal(recal_file, rglist, &recaldata);
+  if (num_rg <= 0) {
+    fprintf(stderr, "Failed to read recalibration file or no read groups found\n");
+    for (i = 0; i < MAX_RG; i++) {
+      if (rglist[i]) free(rglist[i]);
+    }
+    free(rglist);
+    if (recaldata) free(recaldata);
+    return 1;
+  }
   num_recal_rg = num_rg;
   if (use_rg != NULL) {
     force_rg_index = get_rg_index(rglist, use_rg, false);
@@ -701,7 +711,13 @@ int main (int argc, char *argv[])
       if (qlen + 1 > max_length) {
         max_length = qlen + 1;
         kroundup32(max_length);
-        sequence = realloc(sequence, max_length);
+        int8_t *tmp_sequence = realloc(sequence, max_length);
+        if (!tmp_sequence) {
+          fprintf(stderr, "Memory allocation failed for sequence\n");
+          break; // Exit the loop if we can't allocate memory
+        } else {
+          sequence = tmp_sequence;
+        }
 //      quality = realloc(quality, max_length);
       }
       sequence[qlen] = '\0';
@@ -722,7 +738,7 @@ int main (int argc, char *argv[])
 
         if (rgID) {
           for (i = 0; i < MAX_RG; i++) {
-            if (rg_data[good_rgfield_index][i]->Value[0] == '\0') {
+            if (rg_data[good_rgfield_index][i] == NULL || rg_data[good_rgfield_index][i]->Value[0] == '\0') {
               break;
             }
             if (strcmp(rg_data[good_rgfield_index][i]->ID, rgID) == 0) {


### PR DESCRIPTION
This PR improves the security and stability of `lacepr.c` by addressing several memory safety concerns:

1. **Full Array Initialization**: In `init_recal`, the loops for zero-initializing `Context` and `Cycle` arrays were using incorrect boundaries (`MAX_CONTEXT` instead of `MAX_CONTEXT + 1` and `MAX_CYCLE` instead of `MAX_CYCLE_BINS`). This could lead to the use of uninitialized memory.
2. **Safe Memory Reallocation**: Several calls to `realloc` were assigning the result directly to the original pointer. If `realloc` failed, the original memory would be leaked. These have been updated to use temporary pointers and check for `NULL`.
3. **NULL Pointer Checks**: Added defensive checks for `rg_data` elements before they are dereferenced, preventing potential crashes if header parsing or memory allocation for read groups failed.
4. **Improved Error Handling**: Added proper cleanup (freeing `rglist` and `recaldata`) when the recalibration file fails to read or contains no valid read groups.

These changes enhance the robustness of the tool when dealing with malformed inputs or memory-constrained environments.

---
*PR created automatically by Jules for task [16414374906444110723](https://jules.google.com/task/16414374906444110723) started by @swainechen*