### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix uninitialized memory in lacepr recalibration structures

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -37,3 +37,8 @@
 **Vulnerability:** Double-free of internal `kseq` buffers and potential heap buffer overflow due to missing length validation between sequence and quality strings in FASTQ records.
 **Learning:** Assigning global pointers to internal library buffers (like `kseq`'s `seq.s`) that are managed by the library (e.g., freed via `kseq_destroy`) can lead to double-free vulnerabilities if the global pointer is also explicitly freed. Furthermore, assuming that sequence and quality strings in a FASTQ file are always the same length and null-terminated can lead to out-of-bounds access if only `strlen` is used.
 **Prevention:** Use local pointers for temporary library-managed buffers to avoid accidental double-frees. Always validate that related data fields (like sequence and quality in FASTQ) have matching lengths using the library's provided length fields before processing, and use length-limited copy functions like `memcpy` with manual null-termination.
+
+## 2026-04-23 - Uninitialized Memory in Complex Structures
+**Vulnerability:** Use of uninitialized heap memory in `lacepr.c` due to incorrect manual initialization loops for large nested arrays (`Cycle`, `Context`).
+**Learning:** Manual initialization of complex, multi-dimensional arrays is error-prone. Using `malloc` followed by loops can easily miss elements if loop boundaries are slightly off (e.g., using `MAX_CYCLE` instead of `MAX_CYCLE_BINS`).
+**Prevention:** Prefer `calloc` for initial allocation of large structures to ensure the entire memory block is zero-initialized by the allocator. For reallocated memory, always use `memset` to zero-initialize the newly added space.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -5,6 +5,8 @@
 #include <float.h>
 #include <math.h>
 #include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
 #include "sam.h"
 #include "sam_header.h"
 #include "htslib/sam.h"
@@ -256,35 +258,10 @@ int get_cycle_index (int i) {
 
 // assume we just get an unallocated pointer, make memory and initialize
 recal_t* init_recal (int num_rg) {
-  int i, j, k;
-  recal_t *data = malloc(sizeof(recal_t) * num_rg);
+  recal_t *data = calloc(num_rg, sizeof(recal_t));
   if (!data && num_rg > 0) {
     fprintf(stderr, "Memory allocation failed for recal data\n");
     return NULL;
-  }
-  for (i=0; i < num_rg; i++) {
-    data[i].Quality = 0;
-    data[i].Observations = 0;
-    data[i].Errors = 0;
-    for (j=0; j < MAX_Q+1; j++) {
-      data[i].OrigQual[j].Quality = 0;
-      data[i].OrigQual[j].Observations = 0;
-      data[i].OrigQual[j].Errors = 0;
-    }
-    for (j=0; j < MAX_CONTEXT; j++) {
-      for (k=0; k < MAX_Q+1; k++) {
-        data[i].Context[j].OrigQual[k].Quality = 0;
-        data[i].Context[j].OrigQual[k].Observations = 0;
-        data[i].Context[j].OrigQual[k].Errors = 0;
-      }
-    }
-    for (j=0; j < MAX_CYCLE; j++) {
-      for (k=0; k < MAX_Q+1; k++) {
-        data[i].Cycle[j].OrigQual[k].Quality = 0;
-        data[i].Cycle[j].OrigQual[k].Observations = 0;
-        data[i].Cycle[j].OrigQual[k].Errors = 0;
-      }
-    }
   }
   return data;
 }
@@ -379,6 +356,11 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
                 free(in);
                 fclose(r);
                 return 0;
+              }
+              // The original data had 1 element (initialized in main)
+              // Ensure newly added elements are zero-initialized
+              if (num_rg > 1) {
+                memset(data + 1, 0, sizeof(recal_t) * (num_rg - 1));
               }
               *data_ptr = data;
 	      for (i = 0; i < num_rg; i++) {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Use of uninitialized heap memory in `lacepr.c` due to incorrect manual initialization loops for large nested arrays (`Cycle`, `Context`).
🎯 Impact: Undefined behavior during base quality recalibration or potential leakage of sensitive data from previous memory allocations.
🔧 Fix: Used `calloc` for initial allocation and `memset` for zero-initializing reallocated memory. Added missing standard headers.
✅ Verification: Verified memory initialization logic with a standalone C test script (`verify_mem.c`).

---
*PR created automatically by Jules for task [16805131342773397028](https://jules.google.com/task/16805131342773397028) started by @swainechen*