### PR TITLE
🛡️ Sentinel: Fix NULL pointer dereference in lacepr.c

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,8 @@
 **Vulnerability:** Uninitialized memory usage due to incorrect loop boundaries in `init_recal` and potential memory leaks/crashes from unsafe `realloc` usage.
 **Learning:** Arrays sized by constants like `MAX_CONTEXT + 1` or `MAX_CYCLE_BINS` must be fully initialized using the same constants as loop boundaries. Additionally, assigning `realloc` results directly to the original pointer leads to memory leaks if allocation fails, as the handle to the original block is lost.
 **Prevention:** Always use the exact array size constant (or size-calculating expression) for loop boundaries during initialization. In C, always use a temporary pointer for `realloc` and only update the original pointer after verifying success.
+
+## 2026-04-24 - NULL Pointer Dereference via strtok in lacepr.c
+**Vulnerability:** In `lacepr.c`, the result of `strtok(in, ":")` was immediately dereferenced (`tkn[0]`) without checking if the line contained any delimiters.
+**Learning:** `strtok` returns `NULL` if no delimiters are found in the string (or if the string is empty). Untrusted files (like recalibration tables) can contain malformed lines that trigger this.
+**Prevention:** Always verify that the return value of `strtok` (and similar string parsing functions) is not `NULL` before dereferencing it, especially when processing external input.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -304,7 +304,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
   while ( (bytes = getline(&in, &n, r)) != -1 ) {
     if (bytes > 0) {
       tkn = strtok(in, ":");
-      if (tkn[0] == '#') {
+      if (tkn != NULL && tkn[0] == '#') {
         while (tkn != NULL) {
           tkn = strtok(NULL, ":");
           if (tkn != NULL) {


### PR DESCRIPTION
This PR fixes a NULL pointer dereference vulnerability in the `read_recal` function of `lacepr.c`. 

### 🚨 Severity: MEDIUM

### 💡 Vulnerability
The `strtok` function returns `NULL` if no tokens are found in the string. The original code in `lacepr.c` was immediately dereferencing the returned pointer (`tkn[0]`) to check for a comment character ('#'), which would lead to a segmentation fault if the input line was empty or consisted only of delimiters.

### 🎯 Impact
An attacker could provide a malformed recalibration file that causes `lacepr` to crash, resulting in a Denial of Service.

### 🔧 Fix
Added a `NULL` check to the `if` statement: `if (tkn != NULL && tkn[0] == '#')`.

### ✅ Verification
- Code Review: The fix was reviewed and rated #Correct#.
- Sentinel Journal: Updated `.jules/sentinel.md` with the critical learning.
- Manual verification: Confirmed the logic change correctly guards the dereference.

---
*PR created automatically by Jules for task [16868521844987132347](https://jules.google.com/task/16868521844987132347) started by @swainechen*