### PR TITLE
🛡️ Sentinel: Harden recalibration file parsing in lacepr

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,8 @@
 **Vulnerability:** Uninitialized memory usage due to incorrect loop boundaries in `init_recal` and potential memory leaks/crashes from unsafe `realloc` usage.
 **Learning:** Arrays sized by constants like `MAX_CONTEXT + 1` or `MAX_CYCLE_BINS` must be fully initialized using the same constants as loop boundaries. Additionally, assigning `realloc` results directly to the original pointer leads to memory leaks if allocation fails, as the handle to the original block is lost.
 **Prevention:** Always use the exact array size constant (or size-calculating expression) for loop boundaries during initialization. In C, always use a temporary pointer for `realloc` and only update the original pointer after verifying success.
+
+## 2026-05-23 - strtok State Invalidation and Memory Safety in read_recal
+**Vulnerability:** Potential crash and undefined behavior in `lacepr.c` due to `strtok` state corruption after buffer reallocation, plus memory leaks on `realloc` failure.
+**Learning:** Calling `strtok(NULL, ...)` after a `getline` call that modifies or reallocates the input buffer results in undefined behavior because `strtok`'s internal pointer refers to the old buffer. Additionally, the `data = realloc(data, ...)` pattern leaks memory if allocation fails.
+**Prevention:** Exit parsing loops with `break` immediately after operations that modify the input buffer to prevent `strtok` from using invalid state. Always use a temporary pointer for `realloc` and validate success before updating the original variable.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -304,7 +304,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
   while ( (bytes = getline(&in, &n, r)) != -1 ) {
     if (bytes > 0) {
       tkn = strtok(in, ":");
-      if (tkn[0] == '#') {
+      if (tkn != NULL && tkn[0] == '#') {
         while (tkn != NULL) {
           tkn = strtok(NULL, ":");
           if (tkn != NULL) {
@@ -350,14 +350,15 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
                 fclose(r);
 		return(0);
               }
-              data = realloc(data, sizeof(recal_t) * num_rg);
-              if (!data) {
+              recal_t *tmp_data = realloc(data, sizeof(recal_t) * num_rg);
+              if (!tmp_data) {
                 fprintf(stderr, "Memory allocation failed for recal data\n");
                 free(temp_table0);
                 free(in);
                 fclose(r);
                 return 0;
               }
+              data = tmp_data;
               // The original data had 1 element (initialized in main)
               // Ensure newly added elements are zero-initialized
               if (num_rg > 1) {
@@ -369,6 +370,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
                 data[i].Observations = temp_table0[i].Observations;
                 data[i].Errors = temp_table0[i].Errors;
               }
+              break;
             } else if (strcmp(tkn, "RecalTable1") == 0) {
               // RecalTable1 should be:
               // 0 - ReadGroup
@@ -395,6 +397,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
                 }
 //                printf("Table 1: %d, %s, %d, %s, %f, %d, %f\n", parsed, rg, qual, eventtype, empqual, data[rgindex].OrigQual[qual].Observations, data[rgindex].OrigQual[qual].Errors);
               }
+              break;
             } else if (strcmp(tkn, "RecalTable2") == 0) {
               // RecalTable2 should be:
               // 0 - ReadGroup
@@ -436,6 +439,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
                   fprintf (stderr, "Parse error for RecalTable2 on line:\n%s", in);
                 }
               }
+              break;
             }
           }
         }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential NULL pointer dereference, memory leak on realloc failure, and undefined behavior due to strtok state corruption.
🎯 Impact: Crashes or unpredictable behavior when parsing malformed recalibration files. Memory leaks if system resources are low.
🔧 Fix:
- Added NULL check for strtok return value.
- Implemented safe realloc pattern using a temporary pointer.
- Added break statements to exit the metadata loop after getline modifies the buffer, preventing strtok state corruption.
✅ Verification: Verified via code inspection and standalone C reproduction scripts. Syntax verified with a mock compilation.

---
*PR created automatically by Jules for task [8374900929288666484](https://jules.google.com/task/8374900929288666484) started by @swainechen*