### PR TITLE
🛡️ Sentinel: Fix uninitialized memory and resource leaks in lacepr

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -55,3 +55,8 @@
 **Vulnerability:** In `lacepr.c`, the result of `strtok(in, ":")` was immediately dereferenced (`tkn[0]`) without checking if the line contained any delimiters.
 **Learning:** `strtok` returns `NULL` if no delimiters are found in the string (or if the string is empty). Untrusted files (like recalibration tables) can contain malformed lines that trigger this.
 **Prevention:** Always verify that the return value of `strtok` (and similar string parsing functions) is not `NULL` before dereferencing it, especially when processing external input.
+
+## 2026-04-26 - Uninitialized Pointer Arrays and Resource Leaks on Error Paths
+**Vulnerability:** Use of uninitialized pointer arrays (`rglist`) and file handle leaks in the BAM processing branch.
+**Learning:** Initializing an array of pointers with `malloc` leaves the entries containing junk data, which can cause `get_rg_index` to incorrectly identify "unused" slots or cause `free()` to crash during cleanup. Additionally, failing to close external library handles (like `samfile_t`) on early exit paths leads to resource exhaustion.
+**Prevention:** Always use `calloc` for arrays of pointers to ensure they are zero-initialized. Ensure all acquired resources (files, library handles) are explicitly released on every possible error return path before exiting a function or the program.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -181,6 +181,8 @@ int get_rg_index (char** rglist, char* rg, bool insert) {
       if (rglist[0]) {
         strncpy(rglist[0], rg, MAX_FIELD - 1);
         rglist[0][MAX_FIELD - 1] = '\0';
+      } else {
+        return(-1);
       }
       rglist[1] = NULL;
       return(0);
@@ -195,6 +197,8 @@ int get_rg_index (char** rglist, char* rg, bool insert) {
           if (rglist[i]) {
             strncpy(rglist[i], rg, MAX_FIELD - 1);
             rglist[i][MAX_FIELD - 1] = '\0';
+          } else {
+            return(-1);
           }
 	  if (i+1 < MAX_RG) { rglist[i+1] = NULL; }
 	  return(i);
@@ -638,12 +642,11 @@ int main (int argc, char *argv[])
   rg = 0;
 
   // read in the recal table
-  rglist = malloc(MAX_RG * sizeof(char*));
+  rglist = calloc(MAX_RG, sizeof(char*));
   if (!rglist) {
     fprintf(stderr, "Memory allocation failed for rglist\n");
     return 1;
   }
-  rglist[0] = NULL;
   recaldata = init_recal(1);
   if (!recaldata) {
     free(rglist);
@@ -686,6 +689,8 @@ int main (int argc, char *argv[])
     if (force_rg_index == -1) {
       good_rgfield_index = read_group_check(fp, rglist, num_rg, rg_data, rg_field);
       if (good_rgfield_index == -1) {
+        samclose(outfp);
+        samclose(fp);
         return(-1);
       }
     }


### PR DESCRIPTION
This PR addresses several memory safety and resource management issues in the C component 'lacepr'. Specifically, it ensures that the 'rglist' array is zero-initialized to avoid undefined behavior during lookup or cleanup, adds checks for memory allocation failures in 'get_rg_index', and guarantees that BAM file handles are properly closed on error paths to prevent resource leaks.

---
*PR created automatically by Jules for task [11470393134248612512](https://jules.google.com/task/11470393134248612512) started by @swainechen*