### PR TITLE
🛡️ Sentinel: Fix memory leak in read_group_check

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -65,3 +65,8 @@
 **Vulnerability:** Integer overflow in context indexing, undefined behavior in cycle indexing, and uninitialized memory usage in recalibration parsing.
 **Learning:** Utility functions in C often lack defensive checks on input ranges. Specifically, base-4 indexing without length checks can overflow 32-bit integers, and negating `INT_MIN` is undefined. Using `malloc` for temporary structures can leave stale data if not all entries are overwritten during parsing.
 **Prevention:** Always validate input string lengths before performing base-N calculations. Explicitly check for `INT_MIN` before negation. Prefer `calloc` for zero-initialization of temporary buffers to ensure deterministic behavior on malformed inputs.
+
+## 2026-04-28 - Resource Leak and Potential Crash in read_group_check
+**Vulnerability:** Memory leak and missing NULL check in `lacepr.c` when parsing BAM headers.
+**Learning:** The function `sam_header_parse2` was called without validating its return value and without ever freeing the allocated memory. Since this happened inside a loop, it led to a predictable memory leak and potential DoS.
+**Prevention:** Always validate return values of library functions that allocate resources. When using opaque handles or iterators, ensure the original allocation is tracked separately and explicitly released using the library's provided cleanup function (e.g., `sam_header_free`).

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -472,7 +472,9 @@ int read_group_check (samfile_t *fp, char** rglist, int num_rg, rg_item_t* rg_da
 
   rg_ok = -1;
   for(i = 0; i < 3; i++) {
-    iter = sam_header_parse2(fp->header->text);
+    void *header_ptr = sam_header_parse2(fp->header->text);
+    if (!header_ptr) continue;
+    iter = header_ptr;
     j = 0;
     while (iter = sam_header2key_val(iter, "RG", "ID", KNOWN_RGFIELD[i], &key, &val)) {
       rg_data[i][j] = malloc(sizeof(rg_item_t));
@@ -494,6 +496,7 @@ int read_group_check (samfile_t *fp, char** rglist, int num_rg, rg_item_t* rg_da
         rg_data[i][j]->Value[0] = '\0';
       }
     }
+    sam_header_free(header_ptr);
   }
   for(i = 0; i < 3; i++) {
     rg_check[i] = true;


### PR DESCRIPTION
🛡️ Sentinel: Fix memory leak in read_group_check

### 🚨 Severity: MEDIUM
### 💡 Vulnerability:
The `read_group_check` function in `lacepr/lacepr.c` called `sam_header_parse2` inside a loop but never released the allocated memory. Additionally, it did not check if the allocation was successful before using the resulting pointer.

### 🎯 Impact:
A memory leak would occur every time `read_group_check` was called (3 times per BAM file processing start). For large headers or frequent executions, this could lead to memory exhaustion (Denial of Service). A NULL return from `sam_header_parse2` would cause a segmentation fault.

### 🔧 Fix:
- Stored the pointer returned by `sam_header_parse2` in a `header_ptr` variable.
- Added a NULL check for `header_ptr`.
- Called `sam_header_free(header_ptr)` at the end of each loop iteration to reclaim memory.

### ✅ Verification:
- Performed a manual code review of the logic.
- Verified that `header_ptr` is correctly initialized, checked, and freed.
- Received a `#Correct#` rating from the code review agent.
- Compilation and automated tests were not possible due to the absence of the `HTSlib` and `Bio::DB::Sam` dependencies in the environment.

---
*PR created automatically by Jules for task [12085893535945527498](https://jules.google.com/task/12085893535945527498) started by @swainechen*