### PR TITLE
🛡️ Sentinel: Fix potential heap buffer overflow by using size_t for record lengths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -70,3 +70,8 @@
 **Vulnerability:** Memory leak and missing NULL check in `lacepr.c` when parsing BAM headers.
 **Learning:** The function `sam_header_parse2` was called without validating its return value and without ever freeing the allocated memory. Since this happened inside a loop, it led to a predictable memory leak and potential DoS.
 **Prevention:** Always validate return values of library functions that allocate resources. When using opaque handles or iterators, ensure the original allocation is tracked separately and explicitly released using the library's provided cleanup function (e.g., `sam_header_free`).
+
+## 2026-04-29 - Integer Truncation and Overflow in Record Lengths
+**Vulnerability:** Integer truncation and potential heap buffer overflow due to use of signed `int` for sequence lengths (`qlen`, `max_length`) and loop counters.
+**Learning:** Genomic sequences and BAM/FASTQ files can exceed 2GB (^{31}-1$ bytes), causing signed `int` lengths to overflow to negative values. Casting an unsigned `size_t` (from `kseq`) to `int` and then using it in `memcpy` (which expects `size_t`) results in a massive overflow.
+**Prevention:** Use `size_t` for all memory-related lengths, buffer sizes, and array indices. Avoid manual casts from unsigned to signed types for length data. Use the `%zu` format specifier when printing `size_t` to ensure portable and safe output.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -617,13 +617,13 @@ int main (int argc, char *argv[])
   char preceding;
   char current;
   int cycle;
-  int i;
-  int j;
+  size_t i;
+  size_t j;
   int debug = 0;
-  int qlen;
-  int max_length = 0;
-  int max_aux = 0;
-  int lines = 0;
+  size_t qlen;
+  size_t max_length = 0;
+  size_t max_aux = 0;
+  size_t lines = 0;
   int8_t seq_comp_table[16] = { 0, 8, 4, 12, 2, 10, 9, 14, 1, 6, 5, 13, 3, 11, 7, 15 };
   recal_t *recaldata;
   char *q_pointer;
@@ -779,7 +779,7 @@ int main (int argc, char *argv[])
         if (b->core.flag & 128) {	// second of a pair
           cycle = -cycle;
         }
-        debug && fprintf(stderr, "rgID %s, cycle %d, sequence %d, pre %c, cur %c, orig %d, new %d\n", rgID, cycle, sequence[i], preceding, current, quality[i], newq(quality[i], cycle, preceding, current, recaldata, rg_index));
+        debug && fprintf(stderr, "rgID %s, cycle %d, sequence %zu, pre %c, cur %c, orig %d, new %d\n", rgID, cycle, (size_t)sequence[i], preceding, current, quality[i], newq(quality[i], cycle, preceding, current, recaldata, rg_index));
 	if (force_rg_index == -1) {
           q_pointer[i] = newq(quality[i], cycle, preceding, current, recaldata, rg_index);
         } else {
@@ -861,7 +861,7 @@ int main (int argc, char *argv[])
         fprintf(stderr, "Sequence and quality lengths differ for %s; skipping\n", seq->name.s);
         continue;
       }
-      qlen = (int)seq->seq.l;
+      qlen = seq->seq.l;
       if (qlen + 1 > newquality_size) {
         newquality_size = qlen + 1;
         char *tmp_q = realloc(newquality, newquality_size);
@@ -888,7 +888,7 @@ int main (int argc, char *argv[])
         } else {
           preceding = '.';
         }
-        debug && fprintf(stderr, "cycle %d, sequence %d, pre %c, cur %c, orig %d, new %d\n", cycle, seq_ptr[i], preceding, current, qual_ptr[i] - 33, newq(qual_ptr[i] - 33, cycle, preceding, current, recaldata, rg_index));
+        debug && fprintf(stderr, "cycle %d, sequence %c, pre %c, cur %c, orig %d, new %d\n", cycle, seq_ptr[i], preceding, current, qual_ptr[i] - 33, newq(qual_ptr[i] - 33, cycle, preceding, current, recaldata, rg_index));
         newquality[i] = newq(qual_ptr[i] - 33, cycle, preceding, current, recaldata, rg_index) + 33;
       }
       if (seq->comment.s == NULL || seq->comment.l < 1) {


### PR DESCRIPTION
This PR addresses a potential heap buffer overflow vulnerability in the 'lacepr' C component. 

Vulnerability:
The application used signed 'int' variables to represent genomic sequence lengths and buffer offsets. Genomic records can exceed 2GB, causing these 'int' variables to overflow to negative values. In the FASTQ processing path, an unsigned 'size_t' length from the 'kseq' library was explicitly cast to a signed 'int', which was then used in 'memcpy' (expecting 'size_t'). A negative 'int' cast to 'size_t' results in an extremely large value, leading to a massive heap buffer overflow.

Fix:
- Changed 'qlen', 'max_length', 'i', 'j', 'lines', and 'max_aux' to 'size_t' in 'main'.
- Removed the unsafe '(int)' cast for sequence lengths.
- Updated debug 'fprintf' statements to use '%zu' for printing 'size_t' values correctly.
- Added a security learning entry to '.jules/sentinel.md'.

Verification:
Manual code review confirmed that all related variables were updated and that 'memcpy'/'realloc' calls now use consistent 'size_t' types. Basic syntax was verified via 'sed' inspection. Full compilation was restricted by the absence of external 'htslib' and 'samtools' headers in the environment.

---
*PR created automatically by Jules for task [3379091131508230699](https://jules.google.com/task/3379091131508230699) started by @swainechen*