### PR TITLE
🛡️ Sentinel: Fix potential heap overflow in FASTQ processing

### DIFF
--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -845,7 +845,7 @@ int main (int argc, char *argv[])
         fprintf(stderr, "Sequence and quality lengths differ for %s; skipping\n", kseq_seq->name.s);
         continue;
       }
-      qlen = kseq->seq.l;
+      qlen = kseq_seq->seq.l;
       if (qlen + 1 > newquality_size) {
         newquality_size = qlen + 1;
         char *tmp_q = realloc(newquality, newquality_size);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: TYPO in variable name leading to incorrect buffer size calculation.
🎯 Impact: Potential heap buffer overflow when copying quality scores if the incorrect length was smaller than the actual sequence length. Also causes a compilation error as 'kseq' is a macro name, not a variable.
🔧 Fix: Corrected 'kseq->seq.l' to 'kseq_seq->seq.l'.
✅ Verification: Code inspection and manual verification of variable usage in the FASTQ processing loop.

---
*PR created automatically by Jules for task [88164876970925748](https://jules.google.com/task/88164876970925748) started by @swainechen*