### PR TITLE
🛡️ Sentinel: Fix integer overflow and data integrity in log10binomial

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -79,3 +79,8 @@
 **Vulnerability:** Integer truncation and potential heap buffer overflow due to use of signed `int` for sequence lengths (`qlen`, `max_length`) and loop counters.
 **Learning:** Genomic sequences and BAM/FASTQ files can exceed 2GB (^{31}-1$ bytes), causing signed `int` lengths to overflow to negative values. Casting an unsigned `size_t` (from `kseq`) to `int` and then using it in `memcpy` (which expects `size_t`) results in a massive overflow.
 **Prevention:** Use `size_t` for all memory-related lengths, buffer sizes, and array indices. Avoid manual casts from unsigned to signed types for length data. Use the `%zu` format specifier when printing `size_t` to ensure portable and safe output.
+
+## 2024-05-24 - Data Integrity and Overflow in Binomial Probability Calculation
+**Vulnerability:** The `choose` function suffered from integer division errors and severe overflow for $n > 30$, leading to incorrect recalibration values. The `log10binomial` function also used an inaccurate normal approximation for $n > 100$.
+**Learning:** Implementing mathematical functions like binomial coefficients using standard integer types is prone to overflow even for moderately small $n$. Integer division within these loops further compounds the error.
+**Prevention:** Use the `lgamma` function from `<math.h>` to compute binomial probabilities in the logarithmic domain. This ensures numerical stability, prevents overflows, and allows for exact calculations across all valid ranges of $n$ and $k$.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -47,43 +47,16 @@ void init_cache (int n) {
   }
 }
 
-long choose (int n, int k) {
-  long result = 1;
-  int j = 1;
-  if (k == n || k == 0) {
-    return 1;
-  }
-  if (k > n || k < 0 || n < 1) {
-    return 0;
-  }
-  if (n - k < k) {
-    k = n - k;
-  }
-  while (j < k) {
-    result *= n/j;
-    n--;
-    j++;
-  }
-  return result;
-}
-
 double log10binomial (double kd, int n, double p) {
-  int k;
-  double mean;
-  double stdev;
-  k = lround(kd);
-//printf("kd %f, n %d, p %f\n", kd, n, p);
-  if (k >= 0 && n > 0 && p > 0 && p < 1) {
-    if (n > 100) {
-      // use normal approximation
-      mean = n * p;
-      stdev = sqrt(mean * (1 - p));
-      return (-0.5 * ( (k - mean) * (k - mean) / n / p / (1-p) ) / log(10) - 0.5 * log10(2 * M_PI * n * p * (1-p)));
-    } else {
-      return ( log10(choose(n, k)) + k * log10(p) + (n-k) * log10(1-p) );
-    }
+  int k = lround(kd);
+  if (p <= 0 || p >= 1 || k < 0 || k > n) {
+    return -1e100; // Represent near-zero probability for impossible cases
   }
-  return 0;
+  // Log-binomial using lgamma for robustness and precision:
+  // log10(n! / (k!(n-k)!) * p^k * (1-p)^(n-k))
+  double log_binom = lgamma(n + 1) - lgamma(k + 1) - lgamma(n - k + 1);
+  double log_prob = log_binom + k * log(p) + (n - k) * log(1 - p);
+  return log_prob / log(10);
 }
 
 int delta (int origq, int obs, double err) {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Integer overflow in binomial coefficient calculation and inaccurate normal approximation.
🎯 Impact: Incorrect base quality recalibration for reads with more than 30 observations, leading to data corruption in the output BAM/FASTQ files.
🔧 Fix: Replaced the flawed `choose` function and `log10binomial` approximation with a robust `lgamma`-based implementation in the logarithmic domain.
✅ Verification: Verified with a C test program covering small and large $n$, plus edge cases. Code reviewed and confirmed as correct.

---
*PR created automatically by Jules for task [5328693997349196416](https://jules.google.com/task/5328693997349196416) started by @swainechen*