### PR TITLE
🛡️ Sentinel: Fix memory safety and logic issues in lacepr.c

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -84,3 +84,8 @@
 **Vulnerability:** The `choose` function suffered from integer division errors and severe overflow for $n > 30$, leading to incorrect recalibration values. The `log10binomial` function also used an inaccurate normal approximation for $n > 100$.
 **Learning:** Implementing mathematical functions like binomial coefficients using standard integer types is prone to overflow even for moderately small $n$. Integer division within these loops further compounds the error.
 **Prevention:** Use the `lgamma` function from `<math.h>` to compute binomial probabilities in the logarithmic domain. This ensures numerical stability, prevents overflows, and allows for exact calculations across all valid ranges of $n$ and $k$.
+
+## 2025-05-25 - String Literal Modification and Allocation Safety in lacepr.c
+**Vulnerability:** Undefined behavior from attempting to modify a string literal in-place and potential NULL pointer dereference in the FASTQ branch.
+**Learning:** Assigning a pointer to a string literal (e.g., `char *field = "PU";`) and then modifying it via `field[2] = '\0'` or `strncpy` results in a segmentation fault or undefined behavior because literals are often stored in read-only memory. Additionally, neglecting NULL checks on initial heap allocations for record processing buffers (like `newquality`) can lead to immediate crashes on memory-constrained systems.
+**Prevention:** Use stack-allocated character arrays (e.g., `char field[3] = "PU";`) for small, fixed-length fields that may be modified by user input. Always implement immediate NULL checks and centralized error handling (e.g., `goto cleanup`) for all heap allocations, even initial ones.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -316,6 +316,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
               }
 	      // after this first RecalTable0 we should know the read groups
 	      // and we can allocate memory for the real data structure
+	      num_rg = MAX_RG;
 	      for (i = 0; i < MAX_RG; i++) {
                 if (rglist[i] == NULL) {
                   num_rg = i;
@@ -524,7 +525,7 @@ int main (int argc, char *argv[])
   char *outfile = NULL;
   char *recal_file = NULL;
   char *use_rg = NULL;
-  char *rg_field = "PU";
+  char rg_field[3] = "PU";
   int read_pairnum = 1;
   while (1) {
     int option_index = 0;
@@ -542,7 +543,7 @@ int main (int argc, char *argv[])
     if (getopt_c == -1)
       break;
     switch (getopt_c) {
-      case 'f': rg_field = optarg; break;
+      case 'f': strncpy(rg_field, optarg, 2); rg_field[2] = '\0'; break;
       case 'b': inbam = optarg; break;
       case 'q': infastq = optarg; break;
       case 'p': read_pairnum = atoi(optarg); break;
@@ -551,7 +552,6 @@ int main (int argc, char *argv[])
       case 'o': outfile = optarg; break;
     }
   }
-  if(strlen(rg_field) > 2) { rg_field[2] = '\0'; }
 
   if ( !recal_file || !outfile || ( !inbam && !infastq ) ||
        ( (inbam ? access(inbam, F_OK) : -1) != 0 && (infastq ? access(infastq, F_OK) : -1) != 0 ) ||
@@ -771,6 +771,10 @@ int main (int argc, char *argv[])
     int l;
     size_t newquality_size = MAX_FIELD;
     newquality = malloc(newquality_size);
+    if (!newquality) {
+      fprintf(stderr, "Memory allocation failed for newquality\n");
+      goto cleanup;
+    }
 
     if (read_pairnum != 1 && read_pairnum != 2) {
       read_pairnum = 1;	// default value if invalid


### PR DESCRIPTION
🚨 Severity: HIGH/MEDIUM
💡 Vulnerability: 
1. Potential NULL pointer dereference for `newquality` buffer in FASTQ processing.
2. Undefined behavior from modifying a string literal for `rg_field`.
3. Logic error in read group count calculation when `rglist` is full.

🎯 Impact:
1. Crash (DoS) on memory exhaustion.
2. Segmentation fault or undefined behavior when specifying custom read group fields via `--field`.
3. Failure to process valid recalibration files that utilize the maximum number of allowed read groups (256).

🔧 Fix:
- Added a NULL check immediately after the initial `malloc` for `newquality` in `main`, redirecting to `cleanup`.
- Changed `rg_field` from `char*` to `char[3]` and used `strncpy` with explicit null-termination for safe user input handling.
- Initialized `num_rg` to `MAX_RG` in `read_recal` before the scanning loop to ensure correct count even if no NULL terminator is found in `rglist`.

✅ Verification: 
Manual code review and inspection of the modified blocks confirmed the fixes correctly address the vulnerabilities. Compilation was not performed as the environment lacks the external `samtools-1.1` and `htslib-1.1` libraries required by `lacepr`.

---
*PR created automatically by Jules for task [15469573623540421651](https://jules.google.com/task/15469573623540421651) started by @swainechen*