### PR TITLE
🛡️ Sentinel: Fix potential NULL pointer dereference in read_group_check

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -93,3 +93,8 @@
 **Vulnerability:** Undefined behavior from attempting to modify a string literal in-place and potential NULL pointer dereference in the FASTQ branch.
 **Learning:** Assigning a pointer to a string literal (e.g., `char *field = "PU";`) and then modifying it via `field[2] = '\0'` or `strncpy` results in a segmentation fault or undefined behavior because literals are often stored in read-only memory. Additionally, neglecting NULL checks on initial heap allocations for record processing buffers (like `newquality`) can lead to immediate crashes on memory-constrained systems.
 **Prevention:** Use stack-allocated character arrays (e.g., `char field[3] = "PU";`) for small, fixed-length fields that may be modified by user input. Always implement immediate NULL checks and centralized error handling (e.g., `goto cleanup`) for all heap allocations, even initial ones.
+
+## 2026-05-24 - [NULL Pointer Dereference in read_group_check]
+**Vulnerability:** Potential NULL pointer dereference in `lacepr.c` when accessing `fp->header->text` without validation.
+**Learning:** Structures provided by external libraries (like `samtools`' `samfile_t`) cannot be assumed to be fully populated. Malformed or empty input files can result in valid library handles that contain NULL pointers for internal data fields like header text.
+**Prevention:** Always implement deep defensive NULL checks when navigating through nested structures provided by external libraries before accessing their members or passing them to other library functions.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -444,6 +444,10 @@ int read_group_check (samfile_t *fp, char** rglist, int num_rg, rg_item_t* rg_da
   int i;
   int j;
 
+  if (!fp || !fp->header || !fp->header->text) {
+    fprintf(stderr, "Invalid BAM file or missing header text\n");
+    return -1;
+  }
   rg_ok = -1;
   for(i = 0; i < 3; i++) {
     void *header_ptr = sam_header_parse2(fp->header->text);


### PR DESCRIPTION
This PR fixes a potential NULL pointer dereference vulnerability in the `read_group_check` function in `lacepr/lacepr.c`.

The function was accessing `fp->header->text` without ensuring that `fp` or its members were non-NULL. In some cases, such as with malformed or empty BAM files, the `htslib` library might return a handle that lacks certain header information, leading to a crash.

The fix adds deep defensive NULL checks at the entry of the function, ensuring the stability and security of the tool when handling untrusted or malformed input data.

A corresponding entry has also been added to the Sentinel journal in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6777899693901547292](https://jules.google.com/task/6777899693901547292) started by @swainechen*