### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix stale regex captures and improve input validation in lacer.pl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -98,3 +98,8 @@
 **Vulnerability:** Potential NULL pointer dereference in `lacepr.c` when accessing `fp->header->text` without validation.
 **Learning:** Structures provided by external libraries (like `samtools`' `samfile_t`) cannot be assumed to be fully populated. Malformed or empty input files can result in valid library handles that contain NULL pointers for internal data fields like header text.
 **Prevention:** Always implement deep defensive NULL checks when navigating through nested structures provided by external libraries before accessing their members or passing them to other library functions.
+
+## 2024-05-26 - Stale Regex Captures and Implicit Variable Misuse in Perl
+**Vulnerability:** In `lacer.pl`, regex capture variables () were used without verifying match success, and `chomp` was used on the implicit global $_ instead of the explicit loop variable.
+**Learning:** Perl's capture variables like $1 retain their value from the previous successful match if the current match fails. This leads to "sticky" state across loop iterations. Similarly, `chomp` without an argument targets $_ even if a different variable was used to read from the filehandle.
+**Prevention:** Always wrap regex matches in `if` blocks before accessing capture variables. Explicitly specify the target variable for `chomp` when using named loop variables (e.g., `chomp $line`).

--- a/lacer.pl
+++ b/lacer.pl
@@ -321,8 +321,9 @@ if (length $region && -f $region) {
   while ($j = <$reg_fh>) {
     next if $j =~ /^#/;
     next if $j =~ /^$/;
-    chomp;
+    chomp $j;
     ($chrom, $start, $end) = split /\s+/, $j;
+    next if !defined $chrom || !defined $start || !defined $end;
     # bed file is 0-based so correct range, but only need start
     $start++;
     for ($i = $start; $i <= $end; $i += $windowsize) {
@@ -379,9 +380,11 @@ if ($USE_READGROUPS) {
   @f = split /\n/, $bam_comments;
   foreach $i (@f) {
     if ($i =~ /^\@RG/) {
-      $i =~ /ID:(\S+)/;
-      $rg = $1;
-      $rg = "NULL" if !defined $rg;
+      if ($i =~ /ID:(\S+)/) {
+        $rg = $1;
+      } else {
+        $rg = "NULL";
+      }
       push(@RG_LIST, $rg);
       foreach $j (qw(ID PL PU LB SM)) {
         if ($i =~ /$j:(\S+)/) {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability:
- Read group ID parsing in BAM headers used stale regex capture variables if a line was malformed.
- Regions file parsing used `chomp` on the wrong variable and lacked validation for required fields.
🎯 Impact:
- Stale read group IDs could lead to incorrect recalibration data being applied to reads, compromising data integrity.
- Malformed region files could cause the script to process incorrect coordinates or crash with undefined value warnings.
🔧 Fix:
- Wrapped regex captures in `if` statements to ensure they are only updated on success.
- Explicitly targetted the correct variable with `chomp`.
- Added `defined` checks for chromosome and position fields.
✅ Verification:
- Manual code review confirmed the fixes address the logic bugs.
- `perl -c lacer.pl` verified no syntax errors were introduced.

---
*PR created automatically by Jules for task [3735934436941002817](https://jules.google.com/task/3735934436941002817) started by @swainechen*