### PR TITLE
🛡️ Sentinel: Fix potential integer overflow in observation counts

### DIFF
--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -47,8 +47,8 @@ void init_cache (int n) {
   }
 }
 
-double log10binomial (double kd, int n, double p) {
-  int k = lround(kd);
+double log10binomial (double kd, long long n, double p) {
+  long long k = llround(kd);
   if (p <= 0 || p >= 1 || k < 0 || k > n) {
     return -1e100; // Represent near-zero probability for impossible cases
   }
@@ -59,7 +59,7 @@ double log10binomial (double kd, int n, double p) {
   return log_prob / log(10);
 }
 
-int delta (int origq, int obs, double err) {
+int delta (int origq, long long obs, double err) {
   int i;
   int maxi = -1;
   double temp;
@@ -262,7 +262,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
   double estqual;
   int qual;
   char eventtype[4];
-  int obs;
+  long long obs;
   double err;
   int rgindex;
   int covindex;
@@ -298,7 +298,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
               bytes = getline(&in, &n, r);
               while ((bytes = getline(&in, &n, r)) != -1 && !whitespaceline(in)) {
                 // Limit input lengths to prevent buffer overflows
-                parsed = sscanf(in, "%255s %3s %lf %lf %d %lf", rg, eventtype, &empqual, &estqual, &obs, &err);
+                parsed = sscanf(in, "%255s %3s %lf %lf %lld %lf", rg, eventtype, &empqual, &estqual, &obs, &err);
                 if (parsed == 6) {
                   rgindex = get_rg_index(rglist, rg, true);
                   if (rgindex < 0 || rgindex >= MAX_RG) {
@@ -362,7 +362,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
               bytes = getline(&in, &n, r);
               while ((bytes = getline(&in, &n, r)) != -1 && !whitespaceline(in)) {
                 // Limit input lengths to prevent buffer overflows
-                parsed = sscanf(in, "%255s %d %3s %lf %d %lf", rg, &qual, eventtype, &empqual, &obs, &err);
+                parsed = sscanf(in, "%255s %d %3s %lf %lld %lf", rg, &qual, eventtype, &empqual, &obs, &err);
                 if (parsed == 6 && strcmp(eventtype,"M") == 0) {
                   rgindex = get_rg_index(rglist, rg, false);
                   if (rgindex < 0 || rgindex >= num_rg || qual < 0 || qual > MAX_Q) {
@@ -391,7 +391,7 @@ int read_recal (char* file, char** rglist, recal_t **data_ptr) {
               bytes = getline(&in, &n, r);
               while ((bytes = getline(&in, &n, r)) != -1 && !whitespaceline(in)) {
                 // Limit input lengths to prevent buffer overflows
-                parsed = sscanf(in, "%255s %d %255s %255s %3s %lf %d %lf", rg, &qual, covariate, covname, eventtype, &empqual, &obs, &err);
+                parsed = sscanf(in, "%255s %d %255s %255s %3s %lf %lld %lf", rg, &qual, covariate, covname, eventtype, &empqual, &obs, &err);
                 if (parsed == 8 && strcmp(eventtype,"M") == 0) {
                   rgindex = get_rg_index(rglist, rg, false);
                   if (rgindex < 0 || rgindex >= num_rg || qual < 0 || qual > MAX_Q) {

--- a/lacepr/lacepr.h
+++ b/lacepr/lacepr.h
@@ -57,7 +57,7 @@ const double prior[] = {
 
 typedef struct {
   int Quality;
-  int Observations;
+  long long Observations;
   double Errors;
 } point_recal_t;
 
@@ -82,7 +82,7 @@ typedef struct {
 // data[0].Context[5].OrigQual[25].Observations for table 2, context 5, qual 25
 typedef struct {
   int Quality;
-  int Observations;
+  long long Observations;
   double Errors;
   point_recal_t OrigQual[MAX_Q + 1];
   recal_set_t Cycle[MAX_CYCLE_BINS];
@@ -105,3 +105,6 @@ int whitespaceline (const char *s) {
 int get_rg_index (char** rglist, char* rg, bool insert);
 int get_context_index (char *s);
 int get_cycle_index (int c);
+double log10binomial (double kd, long long n, double p);
+int delta (int origq, long long obs, double err);
+int read_recal (char* file, char** rglist, recal_t **data_ptr);


### PR DESCRIPTION
The 'Observations' count in recalibration tables can easily exceed the 2.1 billion limit of a signed 32-bit integer in modern high-depth genomic sequencing. An overflow here would lead to incorrect probability calculations in 'log10binomial' and 'delta', resulting in corrupted recalibration quality scores.

This PR:
1. Changes the 'Observations' field type to 'long long' in 'point_recal_t' and 'recal_t' structures.
2. Updates 'log10binomial' and 'delta' function signatures and internal logic to use 'long long' for observation counts.
3. Updates 'read_recal' to use 'long long' for the 'obs' local variable and '%lld' in 'sscanf' to parse 64-bit integers.
4. Adds updated function prototypes to 'lacepr.h' for consistency.

These changes ensure the tool is robust enough to handle extremely large genomic datasets without data corruption from integer overflows.

---
*PR created automatically by Jules for task [5944613436915320673](https://jules.google.com/task/5944613436915320673) started by @swainechen*