### PR TITLE
Prevent DoS via autovivification on shared hash in lacer.pl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -118,3 +118,8 @@
 **Vulnerability:** A `next` statement was used outside of an explicit loop block in `lacer.pl`'s region parsing logic, causing a fatal error and DoS.
 **Learning:** In Perl, using `next`, `last`, or `redo` outside of a loop block is a fatal error. This can happen when logic is moved into or out of loops during refactoring.
 **Prevention:** Ensure loop control keywords are strictly used within loop scopes. Use structured conditional blocks (`if/else`) for parameter validation outside of loops.
+
+## 2026-05-21 - DoS via Autovivification on Shared Hash in Perl
+**Vulnerability:** A runtime crash ("Invalid value for shared scalar") occurred in `lacer.pl` when accessing nested keys of the shared `$VCFPOS` hash if the parent key (chromosome) was missing.
+**Learning:** Perl's autovivification feature automatically creates hash references for missing keys. When a hash is shared using `threads::shared`, this automatic mutation from a worker thread can violate the shared structure's constraints, causing a fatal error.
+**Prevention:** Always use multi-stage defensive checks (e.g., `if (defined $hash->{$key1} && defined $hash->{$key1}->{$key2})`) when reading from shared nested structures to prevent accidental mutation via autovivification.

--- a/lacer.pl
+++ b/lacer.pl
@@ -559,7 +559,8 @@ sub worker {
     # first pass - call consensus
     return if ($pos < $first || $pos > $last);
     if ($INCLUDEVCF) {
-      return if !defined $VCFPOS->{$seqid}->{$pos};
+      # SECURITY: Prevent autovivification on shared hash which causes runtime crash
+      return if !defined $VCFPOS->{$seqid} || !defined $VCFPOS->{$seqid}->{$pos};
     } else {
       return if defined $VCFPOS->{$seqid} && defined $VCFPOS->{$seqid}->{$pos};
     }


### PR DESCRIPTION
Modified `lacer.pl` to prevent a runtime crash caused by autovivification on the shared `$VCFPOS` hash when using the `-includevcf` option. Added a Sentinel journal entry documenting the vulnerability and its prevention.

---
*PR created automatically by Jules for task [10900245881961206768](https://jules.google.com/task/10900245881961206768) started by @swainechen*