### PR TITLE
🛡️ Sentinel: Fix DoS vulnerability via unpack fatal errors

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -124,6 +124,11 @@
 **Learning:** In Perl, using `next`, `last`, or `redo` outside of a loop block is a fatal error. This can happen when logic is moved into or out of loops during refactoring.
 **Prevention:** Ensure loop control keywords are strictly used within loop scopes. Use structured conditional blocks (`if/else`) for parameter validation outside of loops.
 
+## 2026-05-22 - DoS via unpack Fatal Error in Perl
+**Vulnerability:** In `lacer.pl`, the `unpack` function was called with an `x` (skip) offset derived from BAM record positions without validating that the offset was within the string's length. This caused fatal " 'x' outside of string" exceptions, leading to Denial of Service.
+**Learning:** Perl's `unpack` function is not always safe; certain format characters like `x` trigger fatal errors if they attempt to move the pointer beyond the string boundary. This is particularly risky when offsets are calculated from external data or relative record positions.
+**Prevention:** Always implement defensive bounds checking before calling `unpack` with variable offsets. Verify that `length($string) > $offset` and handle out-of-bounds cases gracefully by returning placeholder values or skipping the record.
+
 ## 2026-05-21 - DoS via Autovivification on Shared Hash in Perl
 **Vulnerability:** A runtime crash ("Invalid value for shared scalar") occurred in `lacer.pl` when accessing nested keys of the shared `$VCFPOS` hash if the parent key (chromosome) was missing.
 **Learning:** Perl's autovivification feature automatically creates hash references for missing keys. When a hash is shared using `threads::shared`, this automatic mutation from a worker thread can violate the shared structure's constraints, causing a fatal error.

--- a/lacer.pl
+++ b/lacer.pl
@@ -584,7 +584,13 @@ sub worker {
       $a[$i] = $p->alignment;
       $aln = $a[$i];
       next if !$aln->qual || $aln->qual < $MINMAPQ;
-      $tempq = unpack("x". ($p->qpos) . "C", $aln->_qscore);
+      my $q_scores = $aln->_qscore;
+      # SECURITY: Validate offset and length before unpack to prevent fatal error (DoS)
+      if (!defined $q_scores || length($q_scores) <= $p->qpos) {
+        warn "Warning: Invalid quality scores for alignment at $seqid:$pos. Skipping.\n";
+        next;
+      }
+      $tempq = unpack("x". ($p->qpos) . "C", $q_scores);
       next if $tempq < $MINQ;
       $cov++;
       if ($USE_READGROUPS) {
@@ -1121,7 +1127,11 @@ sub get_context {
   my $l;
   my $base;
 
+  # SECURITY: Validate sequence and position before unpack to prevent fatal DoS
+  if (!defined $sequence) { return ("..", "."); }
   $l = length($sequence);
+  if ($position < 0 || $position >= $l) { return ("..", "."); }
+
   if ($position > 0) {
     ($left, $base) = unpack("x" . ($position - 1) . "A1A1", $sequence);
   } else {
@@ -1152,7 +1162,11 @@ sub get_contextpre {
   # we are giving the two bases before the indicated base here
   my $pre1 = "";
   my $pre2 = "";
+  # SECURITY: Validate sequence and position before unpack to prevent fatal DoS
+  if (!defined $sequence) { return ("..", "."); }
   my $l = length($sequence);
+  if ($position < 0 || $position >= $l) { return ("..", "."); }
+
   my $base;
   if ($strand > 0) {
     if ($position > 1) {
@@ -1201,7 +1215,11 @@ sub get_2base {
   my $temp;
   my $l;
 
+  # SECURITY: Validate sequence and position before unpack to prevent fatal DoS
+  if (!defined $sequence) { return ("..", "."); }
   $l = length($sequence);
+  if ($position < 0 || $position >= $l) { return ("..", "."); }
+
   if ($strand > 0) {
     if ($position > 0) {
       ($preceding, $indicated) = unpack("x" . ($position - 1) . "A1A1", $sequence);


### PR DESCRIPTION
This PR fixes a Denial of Service (DoS) vulnerability in `lacer.pl` where fatal exceptions were triggered by the `unpack` function when provided with out-of-bounds offsets. Defensive checks have been added to ensure all string skip operations are within the bounds of the input data.

---
*PR created automatically by Jules for task [6179264828275394875](https://jules.google.com/task/6179264828275394875) started by @swainechen*