### PR TITLE
🛡️ Sentinel: Fix out-of-bounds read in BAM parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -133,3 +133,8 @@
 **Vulnerability:** A runtime crash ("Invalid value for shared scalar") occurred in `lacer.pl` when accessing nested keys of the shared `$VCFPOS` hash if the parent key (chromosome) was missing.
 **Learning:** Perl's autovivification feature automatically creates hash references for missing keys. When a hash is shared using `threads::shared`, this automatic mutation from a worker thread can violate the shared structure's constraints, causing a fatal error.
 **Prevention:** Always use multi-stage defensive checks (e.g., `if (defined $hash->{$key1} && defined $hash->{$key1}->{$key2})`) when reading from shared nested structures to prevent accidental mutation via autovivification.
+
+## 2026-05-31 - Out-of-bounds Read in BAM Auxiliary Tag and Record Parsing
+**Vulnerability:** Out-of-bounds read when parsing BAM auxiliary tags and accessing quality scores in `lacepr.c`.
+**Learning:** `bam_aux_get` returns a pointer to the tag value in the record's data buffer. For 'Z' type tags (strings), standard C string functions like `strcmp` will read past the buffer if the tag is not null-terminated within the record data. Furthermore, calculating offsets for quality data without checking against `b->l_data` can lead to OOB reads if the record is truncated.
+**Prevention:** Always use `memchr` to verify null-termination of string-type auxiliary tags within the bounds of the remaining BAM record data. Validate all derived offsets and lengths against the total record data size (`b->l_data`) before pointer dereferencing or passing to string functions.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -739,6 +739,11 @@ int main (int argc, char *argv[])
       rawdata = bam_get_seq(b);
       // Removed stack-allocated backup array to prevent stack overflow
       int offset = ((b)->core.n_cigar<<2) + (b)->core.l_qname + (((b)->core.l_qseq + 1)>>1);
+      if (offset < 0 || (uint32_t)offset + qlen > b->l_data) {
+        fprintf(stderr, "Malformed BAM: record truncated\n");
+        res = 1;
+        goto cleanup;
+      }
       quality = b->data + offset;
 
       // deal with read groups again
@@ -747,7 +752,11 @@ int main (int argc, char *argv[])
       if (force_rg_index == -1) {
         rg = bam_aux_get(b, "RG");
         if (rg && rg[0] == 'Z') {
-          rgID = (char*)(rg + 1);
+          char *rg_val = (char*)(rg + 1);
+          size_t max_rg_len = (size_t)((b->data + b->l_data) - (uint8_t*)rg_val);
+          if (memchr(rg_val, '\0', max_rg_len)) {
+            rgID = rg_val;
+          }
         }
 
         if (rgID) {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix out-of-bounds read in BAM auxiliary tag and record parsing

🚨 Severity: HIGH
💡 Vulnerability: Out-of-bounds read in BAM record parsing.
🎯 Impact: Denial of Service (DoS) or potential information disclosure via malformed BAM files.
🔧 Fix: Added bounds checking for quality score offsets and null-termination validation for 'RG' auxiliary tags.
✅ Verification: Manual code review and logic validation against BAM format specifications.

---
*PR created automatically by Jules for task [3654776302278626506](https://jules.google.com/task/3654776302278626506) started by @swainechen*