### PR TITLE
🛡️ Sentinel: fix division-by-zero DoS in SVD logic

### DIFF
--- a/lacer.pl
+++ b/lacer.pl
@@ -1249,6 +1249,12 @@ sub get_2base {
 
 sub pdlhist {
   my ($q) = @_;
+
+  # SECURITY: Prevent DoS via division by zero or empty input
+  if ($q->isnull || $q->nelem == 0) {
+    return zeroes($MAXQUAL - $MINQUAL + 1);
+  }
+
   # give back quality hist respecting minqual and maxqual
   # assume qualities are in the first column
   my $min = minimum($q);
@@ -1269,7 +1275,12 @@ sub pdlhist {
   } elsif ($MAXQUAL < $maxhist) {
     $hist = $hist->(:($MAXQUAL - $maxhist));
   }
-  return $hist/sum($hist);
+  my $s = sum($hist);
+  if ($s > 0) {
+    return $hist/$s;
+  } else {
+    return zeroes($MAXQUAL - $MINQUAL + 1);
+  }
 }
 
 sub quality_svd {
@@ -1403,7 +1414,7 @@ sub quality_svd {
   if (!$gatk) {
     print $out_fh "# Initial matrix size ", $matrix->shape, "\n";
     print $out_fh "# Bin size: $bin_size\n";
-    print $out_fh "# SVD fit: ", $s->at(0) * $s->at(0) / inner($s, $s), "\n";
+    print $out_fh "# SVD fit: ", $fit, "\n";
     print $out_fh "# Tolerance: $tolerance\n";
     print $out_fh "# Stdev: $sdev\n";
     print $out_fh "# Candidates: $candidates\n";
@@ -1412,7 +1423,7 @@ sub quality_svd {
     wcols(pdl($MINQUAL..$MAXQUAL), $recalibrated, $hist, $correct, $error, { COLSEP => "\t" });
   }
   
-  return($recalibrated, $s->at(0) * $s->at(0) / inner($s, $s));
+  return($recalibrated, $fit);
 }
 
 sub gatk_header {


### PR DESCRIPTION
This PR addresses several potential Denial of Service (DoS) vulnerabilities in the `lacer.pl` script by hardening the SVD-based recalibration logic against division-by-zero errors.

### 🚨 Severity: MEDIUM
### 💡 Vulnerability: Potential Division by Zero
### 🎯 Impact: 
Malformed or edge-case genomic data (e.g., extremely low coverage or lacking base diversity) could cause the script to crash with a division-by-zero error, leading to a Denial of Service.

### 🔧 Fix:
- In `pdlhist`: Added checks for `isnull` and `nelem == 0` for input PDLs, and validated that the histogram sum is positive before normalization.
- In `quality_svd`: Refactored the return logic to use the already-validated `$fit` variable, ensuring that protection against zero singular values is applied consistently.

### ✅ Verification:
- Verified changes logically via code review.
- Confirmed that the `$fit` variable is correctly defined and scoped within `quality_svd`.
- Syntax checked locally (though full validation is limited by missing PDL dependencies in the environment).

---
*PR created automatically by Jules for task [8405496124274269850](https://jules.google.com/task/8405496124274269850) started by @swainechen*