### PR TITLE
🛡️ Sentinel: Fix potential DoS in pdlhist

### DIFF
--- a/lacer.pl
+++ b/lacer.pl
@@ -1249,6 +1249,10 @@ sub get_2base {
 
 sub pdlhist {
   my ($q) = @_;
+  # SECURITY: Prevent DoS via null or empty PDL
+  if (!defined $q || $q->nelem == 0) {
+    return zeroes($MAXQUAL - $MINQUAL + 1);
+  }
   # give back quality hist respecting minqual and maxqual
   # assume qualities are in the first column
   my $min = minimum($q);
@@ -1269,7 +1273,13 @@ sub pdlhist {
   } elsif ($MAXQUAL < $maxhist) {
     $hist = $hist->(:($MAXQUAL - $maxhist));
   }
-  return $hist/sum($hist);
+  # SECURITY: Prevent DoS via division by zero during normalization
+  my $sum = sum($hist);
+  if ($sum > 0) {
+    return $hist / $sum;
+  } else {
+    return zeroes($MAXQUAL - $MINQUAL + 1);
+  }
 }
 
 sub quality_svd {


### PR DESCRIPTION
This PR hardens the `pdlhist` subroutine in `lacer.pl` to prevent Denial of Service (DoS) attacks or crashes caused by malformed input data. 

Specifically:
- Added a check for `!defined $q` and `$q->nelem == 0` at the start of `pdlhist` to handle null or empty PDL objects gracefully.
- Added a check to ensure the sum of the histogram is greater than zero before normalization (division by sum), avoiding "Illegal division by zero" fatal errors.
- Both cases now return a zeroed PDL of the appropriate size instead of crashing.

This enhancement improves the stability of the recalibration process when encountering low-coverage regions or genomic edge cases.

---
*PR created automatically by Jules for task [14552673555940923282](https://jules.google.com/task/14552673555940923282) started by @swainechen*