### PR TITLE
Fix race conditions in lacer.pl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -138,3 +138,8 @@
 **Vulnerability:** Out-of-bounds read when parsing BAM auxiliary tags and accessing quality scores in `lacepr.c`.
 **Learning:** `bam_aux_get` returns a pointer to the tag value in the record's data buffer. For 'Z' type tags (strings), standard C string functions like `strcmp` will read past the buffer if the tag is not null-terminated within the record data. Furthermore, calculating offsets for quality data without checking against `b->l_data` can lead to OOB reads if the record is truncated.
 **Prevention:** Always use `memchr` to verify null-termination of string-type auxiliary tags within the bounds of the remaining BAM record data. Validate all derived offsets and lengths against the total record data size (`b->l_data`) before pointer dereferencing or passing to string functions.
+
+## 2026-06-01 - Race Conditions on Shared Globals and Signal Handlers
+**Vulnerability:** Race conditions on shared global variables `$MAXQUAL`, `$MINQUAL`, and `@THREADSTATUS` in `lacer.pl`.
+**Learning:** In Perl `threads::shared`, simple scalar and array updates are not atomic. Multiple threads updating `$MAXQUAL` or `$MINQUAL` simultaneously could lead to inconsistent bounds, affecting downstream matrix calculations. Similarly, modifying the `@THREADSTATUS` array from a signal handler (`quit_pileups`) without locking could cause data corruption or race conditions with worker threads.
+**Prevention:** Always use `lock()` before modifying shared variables in Perl. For performance-sensitive updates like quality bounds, use a double-checked locking pattern (check condition, lock, check again, update) to minimize contention while ensuring atomicity.

--- a/lacer.pl
+++ b/lacer.pl
@@ -619,14 +619,18 @@ sub worker {
       $temppos = -$temppos if $aln->get_tag_values("SECOND_MATE");
       $temphist->{$rg[$i]}->{$temppos}->[$tempq]++;	# position specific
       $temphist->{$rg[$i]}->{$context[$i]}->[$tempq]++;
-      if (!$MAXQUAL) {
-        $MAXQUAL = $tempq;
+      # SECURITY: Prevent race condition on global shared quality bounds
+      if (!$MAXQUAL || $tempq > $MAXQUAL || !$MINQUAL || $tempq < $MINQUAL) {
+        lock($MAXQUAL);
+        if (!$MAXQUAL) {
+          $MAXQUAL = $tempq;
+        }
+        if (!$MINQUAL) {
+          $MINQUAL = $tempq;
+        }
+        if ($tempq > $MAXQUAL) { $MAXQUAL = $tempq; }
+        if ($tempq < $MINQUAL) { $MINQUAL = $tempq; }
       }
-      if (!$MINQUAL) {
-        $MINQUAL = $tempq;
-      }
-      if ($tempq > $MAXQUAL) { $MAXQUAL = $tempq; }
-      if ($tempq < $MINQUAL) { $MINQUAL = $tempq; }
       $base->{$nt[$i]}++;
     }
     # if we're high coverage, we still need the histograms, but don't use these
@@ -1665,6 +1669,7 @@ sub sigint_handler {
 
 sub quit_pileups {
   my $i;
+  lock(@THREADSTATUS);
   foreach $i (1..$#THREADSTATUS) {
     $THREADSTATUS[$i] = "interrupt" if $THREADSTATUS[$i] eq "started";
   }


### PR DESCRIPTION
Fixed race conditions on shared global variables in lacer.pl using Perl's lock() mechanism. Implemented double-checked locking for performance-sensitive quality bounds updates and standard locking for signal-driven status changes.

---
*PR created automatically by Jules for task [7331441919047357003](https://jules.google.com/task/7331441919047357003) started by @swainechen*