### PR TITLE
🛡️ Sentinel: Fix potential DoS via unpack in lacer.pl

### DIFF
--- a/lacer.pl
+++ b/lacer.pl
@@ -586,7 +586,7 @@ sub worker {
       next if !$aln->qual || $aln->qual < $MINMAPQ;
       my $q_scores = $aln->_qscore;
       # SECURITY: Validate offset and length before unpack to prevent fatal error (DoS)
-      if (!defined $q_scores || length($q_scores) <= $p->qpos) {
+      if (!defined $q_scores || $p->qpos < 0 || length($q_scores) <= $p->qpos) {
         warn "Warning: Invalid quality scores for alignment at $seqid:$pos. Skipping.\n";
         next;
       }


### PR DESCRIPTION
### 🛡️ Sentinel: Fix potential DoS via unpack in lacer.pl

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Potential fatal error in Perl's `unpack` function due to unvalidated negative skip offset.
🎯 **Impact**: If a malformed or malicious BAM record provides a negative quality position offset, `lacer.pl` will encounter a fatal error and terminate immediately, leading to a Denial of Service (DoS) for the processing pipeline.
🔧 **Fix**: Added an explicit check to ensure `$p->qpos` is non-negative before it is used as a skip count in `unpack`. This complements the existing length validation.
✅ **Verification**: Verified the logic via code inspection and ensured no syntax errors were introduced. Removed all temporary test artifacts.

---
*PR created automatically by Jules for task [4045655981979325371](https://jules.google.com/task/4045655981979325371) started by @swainechen*