### PR TITLE
🛡️ Sentinel: Fix memory exhaustion DoS in lacer.pl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -148,3 +148,8 @@
 **Vulnerability:** A Denial of Service (DoS) vulnerability (runtime crash) existed in `lacer.pl` when the `-noreadgroups` flag was used. The `$rginfo` hash reference was only initialized inside an `if ($USE_READGROUPS)` block, leading to a fatal "Can't use an undefined value as a HASH reference" error during GATK table generation.
 **Learning:** Conditional initialization of global data structures based on command-line flags is dangerous if downstream logic assumes those structures are always defined. Even if read group processing is skipped, the final reporting phase still dereferences the structure to obtain metadata for the "NULL" group.
 **Prevention:** Ensure all primary data structures are initialized with safe default values (e.g., a "NULL" entry) in the global scope or immediately after command-line parsing, independent of conditional logic blocks.
+
+## 2024-06-05 - Memory Exhaustion DoS via Arbitrary Read Group Tags
+**Vulnerability:** Denial of Service (DoS) via memory exhaustion by injecting millions of unique or excessively long Read Group (RG) tags into BAM alignment records.
+**Learning:** Even if the number of entries in a file header is limited, the content of individual records (like RG tags in BAM alignments) can still be used to inject arbitrary keys into internal hashes. If these hashes are shared across threads, memory growth can be rapid and fatal.
+**Prevention:** Always truncate string-based identifiers used as hash keys and validate them against a known whitelist (e.g., the set of Read Groups declared in the header) before processing the record.

--- a/lacer.pl
+++ b/lacer.pl
@@ -455,7 +455,7 @@ if ($USE_READGROUPS) {
   foreach $i (@f) {
     if ($i =~ /^\@RG/) {
       if ($i =~ /ID:(\S+)/) {
-        $rg = $1;
+        $rg = substr($1, 0, 255);
       } else {
         $rg = "NULL";
       }
@@ -468,7 +468,7 @@ if ($USE_READGROUPS) {
       push(@RG_LIST, $rg);
       foreach $j (qw(ID PL PU LB SM)) {
         if ($i =~ /$j:(\S+)/) {
-          $rginfo->{$rg}->{$j} = $1;
+          $rginfo->{$rg}->{$j} = substr($1, 0, 255);
         } else {
           $rginfo->{$rg}->{$j} = "NULL";
         }
@@ -534,6 +534,7 @@ sub worker {
   my $first;
   my $last;
   my $alldata = {};
+  my %VALID_RG = map { $_ => 1 } @RG_LIST;
   foreach $rg (@RG_LIST) {
     $alldata->{$rg} = retrieve_pdls($prefix . $rg);
   }
@@ -596,12 +597,17 @@ sub worker {
       if ($USE_READGROUPS) {
         $rg[$i] = $aln->aux;
         if ($rg[$i] =~ /RG:Z:(\S+)/) {
-          $rg[$i] = $1;
+          $rg[$i] = substr($1, 0, 255);
         } else {
           $rg[$i] = "NULL";
         }
       } else {
         $rg[$i] = "NULL";
+      }
+      # SECURITY: Validate Read Group to prevent memory exhaustion DoS via arbitrary keys in shared hashes.
+      if (!exists $VALID_RG{$rg[$i]}) {
+        warn "Warning: Read Group '$rg[$i]' not found in BAM header. Skipping alignment at $seqid:$pos.\n";
+        next;
       }
       $temphist->{$rg[$i]}->{0}->[$tempq]++;	# overall histogram
       if ($aln->strand > 0) {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix memory exhaustion DoS via arbitrary Read Group tags in `lacer.pl`

### 🚨 Severity: HIGH

### 💡 Vulnerability:
A malicious or malformed BAM file could contain alignment records with an unbounded number of unique Read Group (RG) tags or excessively long RG strings. Because `lacer.pl` uses these tags as keys in shared hashes across threads, this could lead to rapid memory exhaustion and a Denial of Service (DoS) crash.

### 🎯 Impact:
An attacker could craft a small BAM file that causes the server running `lacer.pl` to run out of memory, potentially affecting other processes on the system.

### 🔧 Fix:
1.  **Truncation:** RG metadata fields (ID, PL, PU, LB, SM) parsed from the header and tags extracted from individual reads are now truncated to 255 characters using `substr`. This provides a hard bound on memory usage per key and maintains compatibility with `lacepr`'s internal limits.
2.  **Whitelist Validation:** A `%VALID_RG` whitelist is created in the `worker` subroutine based on the Read Groups declared in the BAM header (`@RG_LIST`). Every alignment record's RG tag is checked against this whitelist, and unknown tags are skipped with a warning.

### ✅ Verification:
Created a standalone Perl test script `verify_rg_logic.pl` to mock the parsing and validation logic. Verified that:
- Header RG IDs longer than 255 chars are truncated.
- Valid RG IDs are correctly identified.
- Reads with unknown RG tags are filtered out.
- Long RG tags in reads that match truncated header IDs are correctly validated.
- The "NULL" RG group is handled correctly.
All 6 tests passed.

```
1..6
ok 1 - Header RG ID truncated to 255 chars
ok 2 - Valid RG ID parsed correctly
ok 3 - Known RG is valid
ok 4 - Truncated long RG matching header is valid
ok 5 - Unknown RG is invalid
ok 6 - NULL RG is valid if in header
```

---
*PR created automatically by Jules for task [2174526631603671073](https://jules.google.com/task/2174526631603671073) started by @swainechen*