### PR TITLE
🛡️ Sentinel: Fix DoS via unbounded read position covariates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -153,3 +153,8 @@
 **Vulnerability:** Denial of Service (DoS) via memory exhaustion by injecting millions of unique or excessively long Read Group (RG) tags into BAM alignment records.
 **Learning:** Even if the number of entries in a file header is limited, the content of individual records (like RG tags in BAM alignments) can still be used to inject arbitrary keys into internal hashes. If these hashes are shared across threads, memory growth can be rapid and fatal.
 **Prevention:** Always truncate string-based identifiers used as hash keys and validate them against a known whitelist (e.g., the set of Read Groups declared in the header) before processing the record.
+
+## 2026-06-10 - Memory Exhaustion DoS via Unbounded Read Position Covariates
+**Vulnerability:** Denial of Service (DoS) via memory exhaustion in `lacer.pl` by providing BAM records with extremely large read positions or long reads.
+**Learning:** Read positions were used as keys in shared hashes (`$temphist`) without validation or capping. Malformed or extreme data can cause these hashes to grow unbounded, exhausting system memory.
+**Prevention:** Always clamp continuous covariates (like read positions) to a reasonable range (e.g., [-1024, 1024]) before using them as keys in hashes. This limits the memory footprint and ensures compatibility with downstream components.

--- a/lacer.pl
+++ b/lacer.pl
@@ -541,6 +541,7 @@ sub worker {
   my $map_consensus = sub {
     my ($seqid, $pos, $pileup, $sam) = @_;
     my @a;
+    my @pos;
     my $aln;
     my @nt;
     my @rg;
@@ -623,6 +624,11 @@ sub worker {
         ($context[$i], $nt[$i]) = get_2base($aln->qseq, $p->qpos, -1);
       }
       $temppos = -$temppos if $aln->get_tag_values("SECOND_MATE");
+      # SECURITY: Clamp read position to [-1024, 1024] to prevent DoS via memory
+      # exhaustion in shared hashes and maintain compatibility with lacepr's MAX_CYCLE.
+      $temppos = 1024 if $temppos > 1024;
+      $temppos = -1024 if $temppos < -1024;
+      $pos[$i] = $temppos;
       $temphist->{$rg[$i]}->{$temppos}->[$tempq]++;	# position specific
       $temphist->{$rg[$i]}->{$context[$i]}->[$tempq]++;
       # SECURITY: Prevent race condition on global shared quality bounds
@@ -704,13 +710,7 @@ sub worker {
         # Coverage at this coordinate
         push @data, $cov;
         # Position - in read
-        if ($aln->strand > 0) {
-          $temppos = $p->qpos+1;
-        } else {
-          $temppos = $aln->l_qseq - $p->qpos;
-        }
-        $temppos = -$temppos if $aln->get_tag_values("SECOND_MATE");
-        push @data, $temppos;
+        push @data, $pos[$i];
         # context - encoded as integer
         push @data, $context_code{$context[$i]};
         if ($DUMP) {


### PR DESCRIPTION
I identified and fixed a **High Severity Denial of Service (DoS)** vulnerability in `lacer.pl`.

### 💡 Vulnerability
In LACER's base quality recalibration logic, the read position (covariate) was calculated and used directly as a key in a shared histogram hash (`$temphist`). Since BAM records can have arbitrary lengths or malformed position data, an attacker could provide records with extremely large positions, causing the hash to grow unbounded and exhaust system memory.

### 🎯 Impact
Memory exhaustion (DoS) when processing malicious or extremely long-read BAM files. It also caused a potential mismatch with the downstream C component `lacepr`, which enforces a hard limit on read cycles.

### 🔧 Fix
1.  **Clamping:** Implemented a strict clamp on the `$temppos` variable, restricting it to the range `[-1024, 1024]`.
2.  **Optimization:** Refactored the `map_consensus` closure to calculate and clamp the position once in the first pass, store it in a local `@pos` array, and reuse it in the second pass.
3.  **Security Journal:** Documented the vulnerability pattern and prevention strategy in `.jules/sentinel.md`.

### ✅ Verification
-   Created a standalone Perl test script `verify_pos_clamping.pl` to mock the two-pass logic and verify that positions (including second-mate negative positions) are correctly clamped and consistently reused.
-   Verified the syntax and logic via manual code inspection and successful test execution.
-   The core logic change is approximately 15 lines, well within the 50-line security fix guideline.

---
*PR created automatically by Jules for task [9667712800648954459](https://jules.google.com/task/9667712800648954459) started by @swainechen*