### PR TITLE
🛡️ Sentinel: Harden to_int subroutine in lacer.pl

### DIFF
--- a/lacer.pl
+++ b/lacer.pl
@@ -1688,7 +1688,14 @@ sub add_hist {
 sub to_int {
   my (@a) = @_;
   foreach my $i (0..$#a) {
-    $a[$i] += 0;
+    # SECURITY: Ensure all elements are defined and numeric to prevent
+    # "uninitialized value" warnings and maintain stability in downstream
+    # PDL matrix operations.
+    if (!defined $a[$i]) {
+      $a[$i] = 0;
+    } else {
+      $a[$i] += 0;
+    }
   }
   return @a;
 }


### PR DESCRIPTION
Hardened the to_int subroutine in lacer.pl to prevent "uninitialized value" warnings and ensure that all elements passed to PDL are valid numbers. This improves the numeric stability of the recalibration logic, especially when handling sparse histogram data.

---
*PR created automatically by Jules for task [11042023777177303246](https://jules.google.com/task/11042023777177303246) started by @swainechen*