### PR TITLE
🛡️ Sentinel: Fix DoS via Floating-Point Underflow to log(0) in lacer.pl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -173,3 +173,8 @@
 **Vulnerability:** A Denial of Service (DoS) vulnerability (fatal crash) in `lacer.pl` during the recalibration phase. Attempting to dereference nested keys in the shared `$ALLHIST` hash (e.g., `@{$ALLHIST->{$rg}->{0}}`) triggered autovivification, which is fatal for shared scalars in Perl when the parent keys are missing.
 **Learning:** Even in the main thread, dereferencing nested keys of a shared hash can trigger fatal autovivification errors if the structure hasn't been explicitly initialized. This is a recurring vulnerability pattern in this codebase's use of `threads::shared`.
 **Prevention:** Always use multi-stage `exists` checks or the safe navigation pattern to access nested keys in shared hashes. Use a fallback empty reference (e.g., `my $ref = (exists $h->{k1} && exists $h->{k1}->{k2}) ? $h->{k1}->{k2} : []`) before dereferencing.
+
+## 2026-06-16 - DoS via Floating-Point Underflow to log(0) in Perl
+**Vulnerability:** A Denial of Service (DoS) vulnerability in `lacer.pl`'s `gatk_table0` subroutine where taking the logarithm of an error ratio (e.g., `log($sum_error/$sum_hist)`) could trigger a fatal "Can't take log of 0" error.
+**Learning:** Even if individual variables are strictly positive, their quotient can underflow to zero in Perl's floating-point representation. This is a recurring vulnerability pattern in this codebase's mathematical processing.
+**Prevention:** Always capture the result of a division in a temporary variable and explicitly verify it is strictly positive before passing it to the `log()` function, especially when dealing with potentially very small values.

--- a/lacer.pl
+++ b/lacer.pl
@@ -1561,15 +1561,22 @@ sub gatk_table0 {
   my $sum_error = sum($error)->at(0);
   my $sum_reported = sum($reportederror)->at(0);
 
-  # Validate sums to prevent division by zero or log of zero in GATK table output
+  # Validate sums to prevent division by zero or log of zero in GATK table output.
+  # SECURITY: Guard against floating-point underflow that could lead to log(0).
   my $emp_q = 40.0;
   if ($sum_hist > 0 && $sum_error > 0) {
-    $emp_q = -10*log($sum_error/$sum_hist) / log(10);
+    my $emp_ratio = $sum_error / $sum_hist;
+    if ($emp_ratio > 0) {
+      $emp_q = -10 * log($emp_ratio) / log(10);
+    }
   }
 
   my $rep_q = 40.0;
   if ($sum_hist > 0 && $sum_reported > 0) {
-    $rep_q = -10*log($sum_reported/$sum_hist) / log(10);
+    my $rep_ratio = $sum_reported / $sum_hist;
+    if ($rep_ratio > 0) {
+      $rep_q = -10 * log($rep_ratio) / log(10);
+    }
   }
 
   push @return, sprintf("%-12s M% 21.0f.0000% 20.4f% 14d% *.2f\n", $rg, $emp_q, $rep_q, $sum_hist, $width, $sum_error);


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix DoS via Floating-Point Underflow to log(0) in lacer.pl

🚨 Severity: MEDIUM
💡 Vulnerability: A Denial of Service (DoS) vulnerability existed in `lacer.pl`'s `gatk_table0` subroutine. Taking the logarithm of an error ratio (e.g., `log($sum_error/$sum_hist)`) could trigger a fatal "Can't take log of 0" error in Perl if the division result underflowed to zero.
🎯 Impact: The script would crash unexpectedly when processing data with extremely low error rates, even if the individual sums were non-zero.
🔧 Fix: Captured the result of the divisions in temporary variables and verified they are strictly positive before calling the `log()` function.
✅ Verification: Verified using a simulation script (`verify_underflow_fix.pl`) that demonstrated the underflow case no longer crashes the script. Existing core logic tests (`verify_consensus_logic.pl`) also pass.

---
*PR created automatically by Jules for task [4545373121189453756](https://jules.google.com/task/4545373121189453756) started by @swainechen*