### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent DoS via long chromosome names in region flag

### DIFF
--- a/lacer.pl
+++ b/lacer.pl
@@ -382,6 +382,8 @@ if (length $region && -f $region) {
   }
 } elsif (length $region) {
   ($chrom, $range) = split /:/, $region;
+  # SECURITY: Truncate chromosome name to prevent excessive memory allocation in @regions (DoS)
+  $chrom = substr($chrom, 0, 255) if defined $chrom;
   if (defined $range) {
     ($start, $end) = split /-/, $range;
   }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Unbounded chromosome name length in `-region` flag.
🎯 Impact: A maliciously long chromosome name could lead to excessive memory consumption in the `@regions` array, potentially causing a Denial of Service (DoS) through memory exhaustion.
🔧 Fix: Truncated the chromosome name to a maximum of 255 characters using `substr`.
✅ Verification: Verified using a mock Perl script that confirms truncation and ensures the resulting regions are within safe bounds.

---
*PR created automatically by Jules for task [5482469620557952669](https://jules.google.com/task/5482469620557952669) started by @swainechen*