### PR TITLE
🛡️ Sentinel: Harden Read Group parsing in lacer.pl

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -178,3 +178,8 @@
 **Vulnerability:** A Denial of Service (DoS) vulnerability in `lacer.pl`'s `gatk_table0` subroutine where taking the logarithm of an error ratio (e.g., `log($sum_error/$sum_hist)`) could trigger a fatal "Can't take log of 0" error.
 **Learning:** Even if individual variables are strictly positive, their quotient can underflow to zero in Perl's floating-point representation. This is a recurring vulnerability pattern in this codebase's mathematical processing.
 **Prevention:** Always capture the result of a division in a temporary variable and explicitly verify it is strictly positive before passing it to the `log()` function, especially when dealing with potentially very small values.
+
+## 2026-06-27 - Tag Spoofing in Read Group Parsing
+**Vulnerability:** Read Group (RG) tags in BAM headers and alignment records were parsed using unanchored regular expressions, allowing malicious data in user-controllable fields (like Description or other auxiliary tags) to be misidentified as valid Read Groups.
+**Learning:** General regex searches on full lines or concatenated auxiliary strings are inherently ambiguous in structured formats like SAM/BAM. A string like "RG:Z:real" can be spoofed by "DS:Z:RG:Z:fake".
+**Prevention:** Always use structured parsing by splitting on the format's defined delimiters (tabs for SAM) and prefer unambiguous library APIs (like `get_tag_values`) for extracting specific metadata.

--- a/lacer.pl
+++ b/lacer.pl
@@ -459,11 +459,14 @@ if ($USE_READGROUPS) {
   @f = split /\n/, $bam_comments;
   foreach $i (@f) {
     if ($i =~ /^\@RG/) {
-      if ($i =~ /ID:(\S+)/) {
-        $rg = substr($1, 0, 255);
-      } else {
-        $rg = "NULL";
+      my @fields = split /\t/, $i;
+      my %tags;
+      foreach my $field (@fields) {
+        if ($field =~ /^([^:]+):(.*)$/) {
+          $tags{$1} = $2;
+        }
       }
+      $rg = defined $tags{ID} ? substr($tags{ID}, 0, 255) : "NULL";
       next if $seen_rg{$rg}++;
       # SECURITY: Limit the number of read groups to prevent DoS via memory
       # exhaustion and ensure compatibility with lacepr's MAX_RG (256).
@@ -472,8 +475,8 @@ if ($USE_READGROUPS) {
       }
       push(@RG_LIST, $rg);
       foreach $j (qw(ID PL PU LB SM)) {
-        if ($i =~ /$j:(\S+)/) {
-          $rginfo->{$rg}->{$j} = substr($1, 0, 255);
+        if (defined $tags{$j}) {
+          $rginfo->{$rg}->{$j} = substr($tags{$j}, 0, 255);
         } else {
           $rginfo->{$rg}->{$j} = "NULL";
         }
@@ -614,9 +617,11 @@ sub worker {
 
       my $this_rg;
       if ($USE_READGROUPS) {
-        $this_rg = $this_aln->aux;
-        if ($this_rg =~ /RG:Z:(\S+)/) {
-          $this_rg = substr($1, 0, 255);
+        # SECURITY: Use get_tag_values for unambiguous tag retrieval to prevent spoofing
+        # from other auxiliary tags.
+        $this_rg = $this_aln->get_tag_values('RG');
+        if (defined $this_rg) {
+          $this_rg = substr($this_rg, 0, 255);
         } else {
           $this_rg = "NULL";
         }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Read Group (RG) tags in BAM headers and alignment records were parsed using unanchored regular expressions.
🎯 Impact: Malicious data in user-controllable fields (e.g., Description tags or other auxiliary tags) could be misidentified as valid Read Groups, leading to incorrect recalibration or logic bypasses.
🔧 Fix: Implemented tab-aware splitting and tag-mapping for BAM header parsing. Switched to the unambiguous \`get_tag_values('RG')\` method for alignment record processing.
✅ Verification: Created and executed a standalone mock script (\`verify_rg_parsing.pl\`) which confirmed that the new logic is robust against spoofed tag inputs while the old logic was vulnerable.

---
*PR created automatically by Jules for task [12798126413074840691](https://jules.google.com/task/12798126413074840691) started by @swainechen*