### PR TITLE
🛡️ Sentinel: Fix numerical instability and domain errors in log10binomial

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -183,3 +183,8 @@
 **Vulnerability:** Read Group (RG) tags in BAM headers and alignment records were parsed using unanchored regular expressions, allowing malicious data in user-controllable fields (like Description or other auxiliary tags) to be misidentified as valid Read Groups.
 **Learning:** General regex searches on full lines or concatenated auxiliary strings are inherently ambiguous in structured formats like SAM/BAM. A string like "RG:Z:real" can be spoofed by "DS:Z:RG:Z:fake".
 **Prevention:** Always use structured parsing by splitting on the format's defined delimiters (tabs for SAM) and prefer unambiguous library APIs (like `get_tag_values`) for extracting specific metadata.
+
+## 2026-06-28 - Numerical Instability and Domain Errors in log10binomial
+**Vulnerability:** The `log10binomial` function in `lacepr.c` lacked validation for the probability parameter $p$ and trial count $n$. It was also susceptible to producing `NaN` values due to $0 \times -\infty$ operations when $k=0$ or $k=n$.
+**Learning:** Mathematical functions using logarithms must strictly validate their domain. Even if a limit exists (like $x \log x \to 0$ as $x \to 0$), standard library `log()` calls with zero arguments trigger domain errors that propagate as `NaN`, potentially causing undefined behavior when cast to integers.
+**Prevention:** Implement strict input validation for all mathematical parameters (e.g., $p \in [0, 1]$, $n \ge 0$, and non-`NaN`). Use conditional guards to skip logarithmic calculations for terms with zero multipliers to ensure numerical stability at boundary conditions.

--- a/lacepr/lacepr.c
+++ b/lacepr/lacepr.c
@@ -50,7 +50,7 @@ int init_cache (int n) {
 }
 
 double log10binomial (double kd, long long n, double p) {
-  if (isnan(kd) || kd < 0 || kd > (double)n) {
+  if (isnan(kd) || isnan(p) || kd < 0 || n < 0 || kd > (double)n || p < 0.0 || p > 1.0) {
     return -1e100;
   }
   long long k = llround(kd);
@@ -60,7 +60,9 @@ double log10binomial (double kd, long long n, double p) {
   // Log-binomial using lgamma for robustness and precision:
   // log10(n! / (k!(n-k)!) * p^k * (1-p)^(n-k))
   double log_binom = lgamma((double)n + 1.0) - lgamma((double)k + 1.0) - lgamma((double)n - (double)k + 1.0);
-  double log_prob = log_binom + (double)k * log(p) + ((double)n - (double)k) * log(1.0 - p);
+  double term_k = (k > 0) ? (double)k * log(p) : 0.0;
+  double term_nk = (n > k) ? (double)(n - k) * log(1.0 - p) : 0.0;
+  double log_prob = log_binom + term_k + term_nk;
   return log_prob / log(10.0);
 }
 


### PR DESCRIPTION
🛡️ Sentinel: Fix numerical instability and domain errors in log10binomial

This change hardens the `log10binomial` function in `lacepr/lacepr.c` by:
1. Validating that the probability $p$ is between 0 and 1.
2. Ensuring the number of trials $n$ is non-negative.
3. Adding `NaN` checks for input parameters.
4. Implementing conditional guards for logarithmic terms to prevent $0 \times -\infty$ operations when $k=0$ or $k=n$, which avoids `NaN` generation and potential undefined behavior during downstream integer casting.

These enhancements improve the robustness of the recalibration logic against malformed or extreme input data.

---
*PR created automatically by Jules for task [6113798241978192727](https://jules.google.com/task/6113798241978192727) started by @swainechen*